### PR TITLE
feat: WASM exports, gRPC server + CLI binary, completions engine

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,21 +2,66 @@
 
 Thanks for your interest in contributing to ROSQL!
 
+## Prerequisites
+
+- **Rust** (stable) — [rustup.rs](https://rustup.rs)
+- **protoc** — required for proto code generation (`apt-get install protobuf-compiler` on Debian/Ubuntu, `brew install protobuf` on macOS)
+- **buf** (optional) — for proto linting (`buf lint proto/`). Install from [buf.build](https://buf.build/docs/installation)
+- **just** (optional) — command runner. Install from [just.systems](https://just.systems)
+
 ## Getting started
 
 ```sh
 git clone https://github.com/RobotOpsInc/rosql
 cd rosql
-just build
-just test
+just build       # or: cargo build
+just test        # or: cargo test
 ```
+
+## Build variants
+
+```sh
+# Default: parser + drivers (no networking, no WASM)
+cargo build
+
+# WASM package (for frontend editors)
+cargo build --target wasm32-unknown-unknown --features wasm
+
+# gRPC server + CLI binary
+cargo build --features server --bin rosql-parser
+```
+
+## Running checks
+
+```sh
+just check       # runs build + test + clippy + fmt + buf-lint
+```
+
+Or individually:
+
+```sh
+cargo test
+cargo clippy -- -D warnings
+cargo fmt --check
+buf lint proto/
+```
+
+## Proto development
+
+Proto files live in `proto/rosql/v1/`. When you modify a `.proto` file:
+
+1. `cargo build` — the `build.rs` script auto-regenerates Rust types via `prost-build`
+2. `buf lint proto/` — validate proto style compliance
+3. `cargo test` — ensure generated types compile and tests pass
+
+The generated Rust types (`src/proto/rosql.v1.rs`) are not committed — they're regenerated on every build.
 
 ## Submitting changes
 
-1. Fork the repo and create a feature branch
+1. Fork the repo and create a feature branch from `development`
 2. Make your changes
-3. Run `just test` and ensure all tests pass
-4. Open a pull request against `main`
+3. Run `just check` (or the individual commands above) and ensure everything passes
+4. Open a pull request against `development`
 
 ## Reporting issues
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,6 +58,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -962,6 +1012,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "cmake"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -969,6 +1059,12 @@ checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "comfy-table"
@@ -1484,7 +1580,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tonic 0.11.0",
- "tonic-build",
+ "tonic-build 0.11.0",
  "url",
  "yup-oauth2",
 ]
@@ -2042,6 +2138,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2405,6 +2507,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl-probe"
@@ -3046,6 +3154,7 @@ dependencies = [
  "aws-config",
  "aws-sdk-athena",
  "chrono",
+ "clap",
  "duckdb",
  "gcp-bigquery-client",
  "insta",
@@ -3055,12 +3164,15 @@ dependencies = [
  "prost-build 0.13.5",
  "prost-types 0.13.5",
  "serde",
+ "serde-wasm-bindgen",
  "serde_json",
  "sqlx",
  "strsim",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-stream",
  "tonic 0.12.3",
+ "tonic-build 0.12.3",
  "wasm-bindgen",
 ]
 
@@ -3339,6 +3451,17 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-wasm-bindgen"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -4126,6 +4249,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic-build"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9557ce109ea773b399c9b9e5dca39294110b74f1f342cb347a80d1fce8c26a11"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "prost-build 0.13.5",
+ "prost-types 0.13.5",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4314,6 +4451,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,16 +2,22 @@
 name = "rosql"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.80"
 license = "Apache-2.0"
 description = "The query language for ROS2 telemetry data"
 repository = "https://github.com/RobotOpsInc/rosql"
 keywords = ["ros2", "robotics", "telemetry", "query-language", "opentelemetry"]
 categories = ["parser-implementations", "science::robotics"]
 
+[[bin]]
+name = "rosql-parser"
+path = "src/bin/rosql-parser.rs"
+required-features = ["server"]
+
 [features]
 default = []
-wasm = ["dep:wasm-bindgen"]
-robotops-backend = ["dep:tonic"]
+wasm = ["dep:wasm-bindgen", "dep:serde-wasm-bindgen"]
+server = ["dep:tonic", "dep:tokio", "dep:clap", "dep:tokio-stream"]
 sql = ["dep:sqlx", "dep:tokio"]
 duckdb = ["dep:duckdb"]
 athena = ["dep:aws-sdk-athena", "dep:aws-config"]
@@ -30,9 +36,12 @@ prost-types = "0.13"
 
 # Feature-gated optional dependencies
 wasm-bindgen = { version = "0.2", optional = true }
+serde-wasm-bindgen = { version = "0.6", optional = true }
 tonic = { version = "0.12", optional = true }
+clap = { version = "4", optional = true, features = ["derive"] }
 sqlx = { version = "0.8", optional = true, features = ["runtime-tokio", "any", "postgres", "sqlite", "mysql"] }
-tokio = { version = "1", optional = true, features = ["rt"] }
+tokio = { version = "1", optional = true, features = ["rt-multi-thread", "macros", "net"] }
+tokio-stream = { version = "0.1", optional = true, features = ["net"] }
 duckdb = { version = "1", optional = true }
 aws-sdk-athena = { version = "1", optional = true }
 aws-config = { version = "1", optional = true }
@@ -40,8 +49,9 @@ gcp-bigquery-client = { version = "0.22", optional = true }
 
 [build-dependencies]
 prost-build = "0.13"
+tonic-build = "0.12"
 
 [dev-dependencies]
 pretty_assertions = "1"
 insta = { version = "1", features = ["yaml"] }
-tokio = { version = "1", features = ["rt", "macros"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@
 
 ---
 
-ROSQL is a structured query language purpose-built for ROS2 telemetry data stored via [OpenTelemetry](https://opentelemetry.io/). It lets robotics engineers query traces, spans, and metrics using familiar SQL-like syntax with first-class support for ROS2 concepts like nodes, actions, and topic hierarchies. Built in Rust, available as a library, CLI, and WASM package.
+ROSQL is a structured query language purpose-built for ROS2 telemetry data stored via [OpenTelemetry](https://opentelemetry.io/). It lets robotics engineers query traces, logs, and metrics using familiar SQL-like syntax with first-class support for ROS2 concepts like nodes, actions, and topic hierarchies. Built in Rust, available as a library, CLI, gRPC server, and WASM package.
 
 ## Architecture
 
-### Open source pipeline (self-hosted)
+### Pipeline
 
 ```
   ROS2 System
@@ -25,10 +25,10 @@ ROSQL is a structured query language purpose-built for ROS2 telemetry data store
   OTel Collector (opentelemetry-collector-contrib)
        │  OTLP → SQL exporter
        ▼
-  SQL-compatible DB (others supported soon)
+  SQL-compatible DB (PostgreSQL, SQLite, MySQL)
        │  OTel standard schema
        ▼
-  rosql driver (SQLBackend / others supported soon)
+  rosql (parse + execute via ROSQLBackend)
        │
        ▼
   Query results
@@ -41,7 +41,10 @@ ROSQL is a structured query language purpose-built for ROS2 telemetry data store
   │ Mode 1: Parse + Execute (standalone)                │
   │   ROSQL text → parser → AST → ROSQLBackend → DB    │
   ├─────────────────────────────────────────────────────┤
-  │ Mode 2: WASM (frontend editor)                      │
+  │ Mode 2: gRPC Server + CLI                           │
+  │   rosql-parser serve / parse / validate             │
+  ├─────────────────────────────────────────────────────┤
+  │ Mode 3: WASM (frontend editor)                      │
   │   parse() / validate() / get_completions()          │
   └─────────────────────────────────────────────────────┘
 ```
@@ -55,107 +58,110 @@ Add ROSQL to your `Cargo.toml`:
 rosql = "0.1"
 ```
 
-Parse and execute a query against any SQL-compatible database:
+Parse a query:
 
 ```rust
-use rosql::{SQLBackend, ROSQLEngine};
+use rosql::parse;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let backend = SQLBackend::connect("postgresql://localhost/telemetry")?;
-    let engine = ROSQLEngine::new(backend);
-
-    let results = engine.execute("
+fn main() {
+    let ast = parse("
         SELECT span_name, duration
-        FROM spans
-        WHERE ros.node = '/navigation/planner'
+        FROM traces
+        WHERE node = '/navigation/planner'
         ORDER BY duration DESC
         LIMIT 10
-    ")?;
+    ").unwrap();
 
-    println!("{results}");
-    Ok(())
+    println!("{ast:?}");
 }
 ```
 
-See [`examples/`](examples/) for full working examples with fixture data.
+## Feature flags
 
-## Driver support
+| Feature | What it enables | Dependencies |
+|---------|----------------|--------------|
+| *(default)* | Parser, AST, unit system, SQL compiler, proto types | logos, serde, prost |
+| `sql` | `SqlBackend` driver (PostgreSQL, MySQL, SQLite) | sqlx, tokio |
+| `server` | `rosql-parser` gRPC server + CLI binary | tonic, tokio, clap |
+| `wasm` | WASM exports for frontend editors | wasm-bindgen |
+| `duckdb` | DuckDB driver (coming soon — [#18](https://github.com/RobotOpsInc/rosql/issues/18)) | duckdb |
 
-| Driver | Feature flag | Backend | Auth | Status |
-|--------|-------------|---------|------|--------|
-| ANSI SQL | *(default)* | `SQLBackend` | Connection string | v0.1 |
-| PostgreSQL | `postgres` | `PostgresBackend` | Connection string | Coming soon |
-| DuckDB | `duckdb` | `DuckDbBackend` | None (local file) | Coming soon |
-| Pandas | `pandas` | `PandasBackend` | None (in-process) | Coming soon |
-| InfluxDB | `influxdb` | `InfluxDbBackend` | Token / connection string | Coming soon |
-| Athena | `athena` | `AthenaBackend` | AWS IAM | Coming soon |
-| BigQuery | `bigquery` | `BigQueryBackend` | GCP service account | Coming soon |
+## CLI
 
-The default ANSI SQL driver works with any standard SQL-compatible database out of the box — PostgreSQL, MySQL, TimescaleDB, and others that support standard SQL over a connection string.
+Build and use the `rosql-parser` CLI:
 
-## Performance
+```sh
+cargo build --features server --bin rosql-parser
 
-Benchmarks are in progress (Mar 2026). See [BENCHMARKS.md](BENCHMARKS.md) once available, and [#6](https://github.com/RobotOpsInc/rosql/issues/6) for test infrastructure tracking.
+# Parse a query to JSON AST
+rosql-parser parse "FROM traces WHERE duration > 500 ms SINCE 1 hour ago"
 
-## Schema
+# Validate a query
+rosql-parser validate "SELECT * FROM logs"
 
-ROSQL expects telemetry data stored in the [OpenTelemetry schema conventions for ROS2](docs/ros2-otel-conventions.md). This includes standard OTel span and trace tables augmented with ROS2-specific resource and span attributes (`ros.node`, `ros.action.*`, etc.).
+# Get completions at cursor position
+rosql-parser completions "FROM " 5
 
-See the [full schema expectations doc](docs/ros2-otel-conventions.md) for required tables, columns, and attribute mappings.
-
-## Documentation and reference
-
-- [ROSQL Language Spec](https://rosql.org/spec) — full grammar, keywords, and semantics
-- [Driver Architecture](https://rosql.org/drivers) — how backends translate AST to SQL dialects
-
-## Examples
-
-```sql
--- Find the slowest action server callbacks in the last hour
-SELECT ros.node, ros.action.name, span_name, duration
-FROM spans
-WHERE ros.action.name IS NOT NULL
-  AND start_time > now() - INTERVAL '1 hour'
-ORDER BY duration DESC
-LIMIT 20;
-
--- Trace a full action lifecycle by parent span
-SELECT span_name, status, duration, ParentSpanId
-FROM spans
-WHERE TraceId = 'abc123'
-ORDER BY start_time;
-
--- Aggregate latency by node
-SELECT ros.node, AVG(duration) AS avg_duration, COUNT(*) AS call_count
-FROM spans
-GROUP BY ros.node
-ORDER BY avg_duration DESC;
-
--- Validate topic publish rates
-SELECT ros.topic, COUNT(*) / EXTRACT(EPOCH FROM MAX(end_time) - MIN(start_time)) AS msgs_per_sec
-FROM spans
-WHERE ros.topic IS NOT NULL
-GROUP BY ros.topic;
+# Start gRPC server on a Unix socket
+rosql-parser serve --socket /tmp/rosql-parser.sock
 ```
-
-See the [`examples/`](examples/) directory for runnable demos ([#7](https://github.com/RobotOpsInc/rosql/issues/7)).
 
 ## WASM API
 
-The `@robotops/rosql` npm package exposes parsing and validation for use in browser editors and tooling:
+The `@robotops/rosql` npm package exposes parsing and validation for use in browser editors:
 
 ```typescript
-import { parse, validate, getCompletions } from '@robotops/rosql';
+import init, { parse, validate, get_completions } from '@robotops/rosql';
 
-const ast = parse('SELECT span_name FROM spans WHERE ros.node = "/planner"');
-console.log(ast);
+await init();
+
+const result = parse('FROM traces WHERE duration > 500 ms SINCE 1 hour ago');
+console.log(result);
 
 const errors = validate('SELECT bad_column FROM not_a_table');
 console.log(errors);
 
-const completions = getCompletions('SELECT span_name FROM spans WHERE ros.');
+const completions = get_completions('FROM ', 5);
 console.log(completions);
 ```
+
+## Examples
+
+```sql
+-- Find slow navigation actions in the last hour
+SELECT span_name, duration
+FROM traces
+WHERE action_name = '/navigate_to_pose' AND duration > 500 ms
+SINCE 1 hour ago
+ORDER BY duration DESC
+LIMIT 20
+
+-- Cross-signal correlation: errors during low battery
+FROM traces WHERE status = 'ERROR'
+DURING(
+  FROM topics WHERE topic_name = '/battery_state'
+  AND fields['percentage'] < 20
+)
+SINCE yesterday
+
+-- Message causality graph
+MESSAGE JOURNEY FOR TRACE 'abc123def456'
+
+-- Robot health assessment
+HEALTH() FOR ROBOT 'robot_42' SINCE 30 minutes ago
+
+-- Pipeline syntax
+FROM traces
+| WHERE duration > 500 ms
+| FACET robot_id
+| COMPARE TO last week
+```
+
+See the [`examples/`](examples/) directory for runnable demos ([#7](https://github.com/RobotOpsInc/rosql/issues/7)).
+
+## Schema
+
+ROSQL expects telemetry data stored in the [OpenTelemetry schema conventions for ROS2](docs/ros2-otel-conventions.md). This includes standard OTel tables (`otel_traces`, `otel_logs`, `otel_metrics`) augmented with ROS2-specific span attributes (`ros.node`, `ros.action.*`, etc.).
 
 ## Options for running
 
@@ -171,7 +177,12 @@ console.log(completions);
 ```sh
 git clone https://github.com/RobotOpsInc/rosql
 cd rosql
+
+# Library only (default)
 cargo build --release
+
+# gRPC server + CLI binary
+cargo build --release --features server --bin rosql-parser
 ```
 
 ## Local development
@@ -182,7 +193,10 @@ cd rosql
 just build       # build default features
 just test        # run tests
 just build-wasm  # build WASM package
+just check       # full CI: build + test + clippy + fmt + buf-lint
 ```
+
+Prerequisites: Rust (stable), protoc, buf (optional). See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
 
 ## Guidelines for contributing
 

--- a/build.rs
+++ b/build.rs
@@ -1,20 +1,33 @@
 use std::io::Result;
 
 fn main() -> Result<()> {
-    // Generate Rust types from proto files into src/proto/
-    // The generated files are checked into the repo.
     let out_dir = "src/proto";
     std::fs::create_dir_all(out_dir)?;
 
-    prost_build::Config::new().out_dir(out_dir).compile_protos(
-        &[
-            "proto/rosql/v1/parser_service.proto",
-            "proto/rosql/v1/ast.proto",
-            "proto/rosql/v1/result.proto",
-            "proto/rosql/v1/field_registry.proto",
-        ],
-        &["proto/"],
-    )?;
+    // Rerun if proto files change or if features change
+    println!("cargo:rerun-if-changed=proto/");
+    println!("cargo:rerun-if-env-changed=CARGO_FEATURE_SERVER");
+
+    let protos = &[
+        "proto/rosql/v1/parser_service.proto",
+        "proto/rosql/v1/ast.proto",
+        "proto/rosql/v1/result.proto",
+        "proto/rosql/v1/field_registry.proto",
+    ];
+    let includes = &["proto/"];
+
+    // When the `server` feature is enabled, generate gRPC service traits
+    // via tonic-build (includes prost message types automatically).
+    // Otherwise, generate only prost message types.
+    if std::env::var("CARGO_FEATURE_SERVER").is_ok() {
+        tonic_build::configure()
+            .out_dir(out_dir)
+            .compile_protos(protos, includes)?;
+    } else {
+        prost_build::Config::new()
+            .out_dir(out_dir)
+            .compile_protos(protos, includes)?;
+    }
 
     Ok(())
 }

--- a/src/bin/rosql-parser.rs
+++ b/src/bin/rosql-parser.rs
@@ -1,0 +1,277 @@
+//! `rosql-parser` — gRPC server + CLI for ROSQL parsing.
+//!
+//! Build with: `cargo build --features server --bin rosql-parser`
+//!
+//! Usage:
+//!   rosql-parser serve [--socket <path>]     # gRPC server mode
+//!   rosql-parser parse <query>               # CLI parse to JSON
+//!   rosql-parser validate <query>            # CLI validate
+//!   rosql-parser completions <query> <pos>   # CLI completions
+
+use clap::{Parser, Subcommand};
+use std::io::{self, Read};
+
+#[derive(Parser)]
+#[command(name = "rosql-parser", about = "ROSQL parser — gRPC server and CLI")]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Start the gRPC parser server.
+    Serve {
+        /// Unix socket path for the gRPC server.
+        #[arg(long, default_value = "/tmp/rosql-parser.sock")]
+        socket: String,
+
+        /// Log level.
+        #[arg(long, default_value = "info")]
+        log_level: String,
+    },
+
+    /// Parse a ROSQL query and output the AST as JSON.
+    Parse {
+        /// The ROSQL query string. Reads from stdin if omitted.
+        query: Option<String>,
+    },
+
+    /// Validate a ROSQL query.
+    Validate {
+        /// The ROSQL query string. Reads from stdin if omitted.
+        query: Option<String>,
+    },
+
+    /// Get completions at a cursor position.
+    Completions {
+        /// The ROSQL query string.
+        query: String,
+        /// Cursor position (0-based byte offset).
+        cursor_pos: usize,
+    },
+}
+
+#[tokio::main]
+async fn main() {
+    let cli = Cli::parse();
+
+    match cli.command {
+        Commands::Serve { socket, log_level } => {
+            serve(socket, log_level).await;
+        }
+        Commands::Parse { query } => {
+            let query = read_query(query);
+            cmd_parse(&query);
+        }
+        Commands::Validate { query } => {
+            let query = read_query(query);
+            cmd_validate(&query);
+        }
+        Commands::Completions { query, cursor_pos } => {
+            cmd_completions(&query, cursor_pos);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CLI commands
+// ---------------------------------------------------------------------------
+
+fn cmd_parse(query: &str) {
+    match rosql::parse(query) {
+        Ok(ast) => {
+            let _proto = rosql::convert::query_to_proto(&ast);
+            let json = serde_json::json!({
+                "ok": true,
+                "ast": serde_json::to_value(&ast).unwrap_or(serde_json::Value::Null),
+            });
+            println!("{}", serde_json::to_string_pretty(&json).unwrap());
+        }
+        Err(errors) => {
+            let error_list: Vec<serde_json::Value> = errors
+                .iter()
+                .map(|e| serde_json::json!({ "error": e.to_string() }))
+                .collect();
+            let json = serde_json::json!({
+                "ok": false,
+                "errors": error_list,
+            });
+            println!("{}", serde_json::to_string_pretty(&json).unwrap());
+            std::process::exit(1);
+        }
+    }
+}
+
+fn cmd_validate(query: &str) {
+    match rosql::parse(query) {
+        Ok(_) => {
+            let json = serde_json::json!({
+                "valid": true,
+                "errors": [],
+            });
+            println!("{}", serde_json::to_string_pretty(&json).unwrap());
+        }
+        Err(errors) => {
+            let error_list: Vec<serde_json::Value> = errors
+                .iter()
+                .map(|e| serde_json::json!({ "error": e.to_string() }))
+                .collect();
+            let json = serde_json::json!({
+                "valid": false,
+                "errors": error_list,
+            });
+            println!("{}", serde_json::to_string_pretty(&json).unwrap());
+            std::process::exit(1);
+        }
+    }
+}
+
+fn cmd_completions(query: &str, cursor_pos: usize) {
+    let completions = rosql::completions::get_completions(query, cursor_pos);
+    let json = serde_json::to_string_pretty(&completions).unwrap();
+    println!("{json}");
+}
+
+fn read_query(query: Option<String>) -> String {
+    match query {
+        Some(q) => q,
+        None => {
+            let mut buf = String::new();
+            io::stdin()
+                .read_to_string(&mut buf)
+                .expect("failed to read from stdin");
+            buf.trim().to_string()
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// gRPC server
+// ---------------------------------------------------------------------------
+
+async fn serve(socket: String, _log_level: String) {
+    use rosql::proto::rosql_v1::rosql_parser_service_server::{
+        RosqlParserService, RosqlParserServiceServer,
+    };
+    use rosql::proto::rosql_v1::*;
+    use tonic::{Request, Response, Status};
+
+    struct ParserService;
+
+    #[tonic::async_trait]
+    impl RosqlParserService for ParserService {
+        async fn parse(
+            &self,
+            request: Request<ParseRequest>,
+        ) -> Result<Response<ParseResponse>, Status> {
+            let req = request.into_inner();
+            match rosql::parse(&req.query) {
+                Ok(ast) => {
+                    let proto_query = rosql::convert::query_to_proto(&ast);
+                    Ok(Response::new(ParseResponse {
+                        result: Some(parse_response::Result::Query(proto_query)),
+                    }))
+                }
+                Err(errors) => {
+                    let proto_err = rosql::convert::error_to_proto(&errors[0]);
+                    Ok(Response::new(ParseResponse {
+                        result: Some(parse_response::Result::Error(proto_err)),
+                    }))
+                }
+            }
+        }
+
+        async fn validate(
+            &self,
+            request: Request<ValidateRequest>,
+        ) -> Result<Response<ValidateResponse>, Status> {
+            let req = request.into_inner();
+            match rosql::parse(&req.query) {
+                Ok(_) => Ok(Response::new(ValidateResponse {
+                    valid: true,
+                    errors: vec![],
+                    warnings: vec![],
+                })),
+                Err(errors) => {
+                    let diagnostics: Vec<ValidationDiagnostic> = errors
+                        .iter()
+                        .map(|e| {
+                            let (message, location, suggestion) = match e {
+                                rosql::ROSQLError::ParseError {
+                                    message,
+                                    location,
+                                    suggestion,
+                                } => (
+                                    message.clone(),
+                                    Some(rosql::convert::source_location_to_proto(location)),
+                                    suggestion.clone().unwrap_or_default(),
+                                ),
+                                other => (other.to_string(), None, String::new()),
+                            };
+                            ValidationDiagnostic {
+                                message,
+                                location,
+                                severity: DiagnosticSeverity::Error as i32,
+                                suggestion,
+                            }
+                        })
+                        .collect();
+                    Ok(Response::new(ValidateResponse {
+                        valid: false,
+                        errors: diagnostics,
+                        warnings: vec![],
+                    }))
+                }
+            }
+        }
+
+        async fn get_completions(
+            &self,
+            request: Request<GetCompletionsRequest>,
+        ) -> Result<Response<GetCompletionsResponse>, Status> {
+            let req = request.into_inner();
+            let completions =
+                rosql::completions::get_completions(&req.query, req.cursor_position as usize);
+
+            let proto_completions: Vec<Completion> = completions
+                .into_iter()
+                .map(|c| {
+                    let kind = match c.kind {
+                        rosql::completions::CompletionKind::Keyword => CompletionKind::Keyword,
+                        rosql::completions::CompletionKind::DataSource => {
+                            CompletionKind::DataSource
+                        }
+                        rosql::completions::CompletionKind::Field => CompletionKind::Field,
+                        rosql::completions::CompletionKind::Function => CompletionKind::Function,
+                        rosql::completions::CompletionKind::Unit => CompletionKind::Unit,
+                    };
+                    Completion {
+                        label: c.label,
+                        detail: c.detail,
+                        kind: kind as i32,
+                    }
+                })
+                .collect();
+
+            Ok(Response::new(GetCompletionsResponse {
+                completions: proto_completions,
+            }))
+        }
+    }
+
+    // Listen on Unix socket
+    eprintln!("rosql-parser gRPC server starting on {socket}");
+
+    // Remove stale socket file if it exists
+    let _ = std::fs::remove_file(&socket);
+
+    let uds = tokio::net::UnixListener::bind(&socket).expect("failed to bind Unix socket");
+    let uds_stream = tokio_stream::wrappers::UnixListenerStream::new(uds);
+
+    tonic::transport::Server::builder()
+        .add_service(RosqlParserServiceServer::new(ParserService))
+        .serve_with_incoming(uds_stream)
+        .await
+        .expect("gRPC server failed");
+}

--- a/src/completions.rs
+++ b/src/completions.rs
@@ -1,0 +1,338 @@
+//! Context-aware completion engine for ROSQL queries.
+//!
+//! Used by both WASM and gRPC to provide autocomplete suggestions
+//! at a given cursor position in a ROSQL query string.
+
+use serde::{Deserialize, Serialize};
+
+/// A single completion suggestion.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Completion {
+    /// The text to insert.
+    pub label: String,
+    /// Human-readable description.
+    pub detail: String,
+    /// The kind of completion.
+    pub kind: CompletionKind,
+}
+
+/// The kind of a completion suggestion.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum CompletionKind {
+    Keyword,
+    DataSource,
+    Field,
+    Function,
+    Unit,
+}
+
+/// Get context-aware completions at a cursor position in a ROSQL query.
+pub fn get_completions(query: &str, cursor_pos: usize) -> Vec<Completion> {
+    let prefix = &query[..cursor_pos.min(query.len())];
+    let trimmed = prefix.trim();
+
+    // Determine context from the last significant token
+    let upper = trimmed.to_uppercase();
+
+    if upper.is_empty() || is_query_start(&upper) {
+        return query_start_completions();
+    }
+
+    if upper.ends_with("FROM ") || upper.ends_with("FROM") {
+        return data_source_completions();
+    }
+
+    if upper.ends_with("WHERE ")
+        || upper.ends_with("WHERE")
+        || upper.ends_with("AND ")
+        || upper.ends_with("OR ")
+    {
+        return field_completions();
+    }
+
+    if upper.ends_with("SINCE ") || upper.ends_with("SINCE") {
+        return time_completions();
+    }
+
+    if upper.ends_with("COMPARE TO ") || upper.ends_with("COMPARE TO") {
+        return baseline_completions();
+    }
+
+    if upper.ends_with("FORMAT ") || upper.ends_with("FORMAT") {
+        return format_completions();
+    }
+
+    if upper.ends_with("USING ") || upper.ends_with("USING") {
+        return time_basis_completions();
+    }
+
+    if upper.ends_with("LAST ") || upper.ends_with("LAST") {
+        return lifecycle_anchor_completions();
+    }
+
+    // After a number, suggest unit suffixes
+    if trimmed.chars().last().is_some_and(|c| c.is_ascii_digit()) {
+        return unit_completions();
+    }
+
+    // Default: suggest keywords
+    keyword_completions()
+}
+
+// ---------------------------------------------------------------------------
+// Completion providers
+// ---------------------------------------------------------------------------
+
+fn query_start_completions() -> Vec<Completion> {
+    vec![
+        kw("SELECT", "Select specific fields"),
+        kw("FROM", "Query a data source"),
+        kw("MESSAGE JOURNEY", "Trace message causality graph"),
+        kw("MESSAGE PATHS", "Find message paths for a topic"),
+        kw("MESSAGE PATH", "Find path between topic and node"),
+        kw("HEALTH()", "Derived robot health assessment"),
+        kw("ANOMALY()", "Statistical anomaly detection"),
+        kw("PATH DEVIATION", "Spatial trajectory analysis"),
+        kw("TRACE", "Show spans for a trace ID"),
+        kw("SHOW RECORDING", "Find MCAP recordings"),
+        kw("CORRELATE", "Cross-signal correlation"),
+    ]
+}
+
+fn data_source_completions() -> Vec<Completion> {
+    vec![
+        ds("logs", "ROS2 /rosout logs"),
+        ds("traces", "Distributed traces and action spans"),
+        ds("metrics", "System metrics and topic rates"),
+        ds("diagnostics", "ROS2 /diagnostics_agg health"),
+        ds("topics", "Deserialized topic messages"),
+        ds("tf", "TF transform tree"),
+        ds("heartbeats", "Robot liveness data"),
+        ds("recordings", "MCAP recording index"),
+        ds("events", "Discrete events"),
+        ds("odom", "Alias: /odom topic"),
+        ds("joint_states", "Alias: /joint_states topic"),
+        ds("battery", "Alias: /battery_state topic"),
+        ds("cmd_vel", "Alias: /cmd_vel topic"),
+        ds("imu", "Alias: /imu/data topic"),
+    ]
+}
+
+fn field_completions() -> Vec<Completion> {
+    vec![
+        field("duration", "Span duration"),
+        field("status", "Span status (OK/ERROR)"),
+        field("span_name", "Span name"),
+        field("node", "ROS2 node name"),
+        field("action_name", "ROS2 action name"),
+        field("action_status", "Action result status"),
+        field("topic", "ROS2 topic name"),
+        field("service", "Service name"),
+        field("trace_id", "Trace ID"),
+        field("message", "Log message body"),
+        field("severity", "Log severity"),
+        field("publish_rate", "Topic publish rate"),
+        field("cpu_usage", "CPU usage"),
+        field("memory_usage", "Memory usage"),
+        field("robot_id", "Robot identifier"),
+    ]
+}
+
+fn time_completions() -> Vec<Completion> {
+    vec![
+        kw("yesterday", "Since yesterday"),
+        kw("last deployment", "Since last deployment"),
+        kw("last robot restart", "Since last robot restart"),
+        kw("last action failure", "Since last action failure"),
+        kw("last topic drop", "Since last topic drop"),
+        kw("last diagnostic warning", "Since last diagnostic warning"),
+    ]
+}
+
+fn baseline_completions() -> Vec<Completion> {
+    vec![
+        kw("last week", "Compare to previous week"),
+        kw("fleet", "Compare to fleet average"),
+        kw("last deployment", "Compare to before last deployment"),
+    ]
+}
+
+fn format_completions() -> Vec<Completion> {
+    vec![
+        kw("table", "Columnar table output"),
+        kw("timeseries", "Time-bucketed series"),
+        kw("scalar", "Single aggregate value"),
+        kw("trace_tree", "Nested span tree"),
+        kw("graph", "Node/edge adjacency list"),
+        kw("path", "Coordinate path data"),
+    ]
+}
+
+fn time_basis_completions() -> Vec<Completion> {
+    vec![
+        kw("ROS_TIME", "Use ROS simulation time"),
+        kw("WALL_TIME", "Use wall clock time"),
+    ]
+}
+
+fn lifecycle_anchor_completions() -> Vec<Completion> {
+    vec![
+        kw("deployment", "Last deployment"),
+        kw("robot restart", "Last robot restart"),
+        kw("action failure", "Last action failure"),
+        kw("topic drop", "Last topic drop"),
+        kw("diagnostic warning", "Last diagnostic warning"),
+        kw("week", "Last week (for COMPARE TO)"),
+    ]
+}
+
+fn unit_completions() -> Vec<Completion> {
+    vec![
+        unit("ms", "Milliseconds"),
+        unit("s", "Seconds"),
+        unit("min", "Minutes"),
+        unit("h", "Hours"),
+        unit("m", "Meters"),
+        unit("km", "Kilometers"),
+        unit("Hz", "Hertz"),
+        unit("deg", "Degrees"),
+        unit("rad", "Radians"),
+        unit("V", "Volts"),
+        unit("B", "Bytes"),
+        unit("MB", "Megabytes"),
+        unit("Pa", "Pascals"),
+    ]
+}
+
+fn keyword_completions() -> Vec<Completion> {
+    vec![
+        kw("WHERE", "Filter conditions"),
+        kw("SINCE", "Time range start"),
+        kw("BETWEEN", "Time range"),
+        kw("FACET", "Group by dimension"),
+        kw("ORDER BY", "Sort results"),
+        kw("LIMIT", "Limit result count"),
+        kw("FORMAT", "Output format"),
+        kw("COMPARE TO", "Baseline comparison"),
+        kw("FOR ROBOT", "Scope to a robot"),
+        kw("FOR FLEET", "Scope to fleet"),
+        kw("USING", "Time basis (ROS_TIME/WALL_TIME)"),
+    ]
+}
+
+fn is_query_start(upper: &str) -> bool {
+    // Empty or just whitespace
+    upper.is_empty() || upper.chars().all(|c| c.is_whitespace())
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn kw(label: &str, detail: &str) -> Completion {
+    Completion {
+        label: label.into(),
+        detail: detail.into(),
+        kind: CompletionKind::Keyword,
+    }
+}
+
+fn ds(label: &str, detail: &str) -> Completion {
+    Completion {
+        label: label.into(),
+        detail: detail.into(),
+        kind: CompletionKind::DataSource,
+    }
+}
+
+fn field(label: &str, detail: &str) -> Completion {
+    Completion {
+        label: label.into(),
+        detail: detail.into(),
+        kind: CompletionKind::Field,
+    }
+}
+
+fn unit(label: &str, detail: &str) -> Completion {
+    Completion {
+        label: label.into(),
+        detail: detail.into(),
+        kind: CompletionKind::Unit,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn completions_at_start() {
+        let completions = get_completions("", 0);
+        let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+        assert!(labels.contains(&"SELECT"));
+        assert!(labels.contains(&"FROM"));
+        assert!(labels.contains(&"HEALTH()"));
+    }
+
+    #[test]
+    fn completions_after_from() {
+        let completions = get_completions("FROM ", 5);
+        let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+        assert!(labels.contains(&"logs"));
+        assert!(labels.contains(&"traces"));
+        assert!(labels.contains(&"odom"));
+    }
+
+    #[test]
+    fn completions_after_where() {
+        let completions = get_completions("FROM traces WHERE ", 18);
+        let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+        assert!(labels.contains(&"duration"));
+        assert!(labels.contains(&"status"));
+        assert!(labels.contains(&"node"));
+    }
+
+    #[test]
+    fn completions_after_since() {
+        let completions = get_completions("FROM logs SINCE ", 16);
+        let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+        assert!(labels.contains(&"yesterday"));
+        assert!(labels.contains(&"last deployment"));
+    }
+
+    #[test]
+    fn completions_after_number() {
+        let completions = get_completions("FROM traces WHERE duration > 500", 32);
+        let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+        assert!(labels.contains(&"ms"));
+        assert!(labels.contains(&"s"));
+    }
+
+    #[test]
+    fn completions_after_format() {
+        let completions = get_completions("FROM logs FORMAT ", 17);
+        let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+        assert!(labels.contains(&"table"));
+        assert!(labels.contains(&"timeseries"));
+    }
+
+    #[test]
+    fn completions_after_compare_to() {
+        let completions = get_completions("FROM logs COMPARE TO ", 21);
+        let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+        assert!(labels.contains(&"last week"));
+        assert!(labels.contains(&"fleet"));
+    }
+
+    #[test]
+    fn completions_after_using() {
+        let completions = get_completions("FROM logs USING ", 16);
+        let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+        assert!(labels.contains(&"ROS_TIME"));
+        assert!(labels.contains(&"WALL_TIME"));
+    }
+}

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -1,0 +1,601 @@
+//! Conversion between native Rust AST types and proto AST types.
+//!
+//! Used by the gRPC sidecar, CLI, and WASM to serialize parsed ASTs.
+
+use crate::ast;
+use crate::error::ROSQLError;
+use crate::proto::rosql_v1 as pb;
+use crate::span::SourceLocation;
+
+// ===========================================================================
+// Query → Proto
+// ===========================================================================
+
+pub fn query_to_proto(query: &ast::Query) -> pb::RosqlQuery {
+    let query_oneof = match query {
+        ast::Query::Standard(sq) => pb::rosql_query::Query::Standard(standard_query_to_proto(sq)),
+        ast::Query::Pipeline(pq) => pb::rosql_query::Query::Pipeline(pipeline_query_to_proto(pq)),
+        ast::Query::Compound(cq) => pb::rosql_query::Query::Compound(compound_query_to_proto(cq)),
+    };
+    pb::RosqlQuery {
+        query: Some(query_oneof),
+    }
+}
+
+fn standard_query_to_proto(sq: &ast::ROSQLQuery) -> pb::StandardQuery {
+    pb::StandardQuery {
+        selections: sq.selections.iter().map(selection_to_proto).collect(),
+        data_source: Some(data_source_to_proto(&sq.data_source)),
+        robot_scope: sq.robot_scope.as_ref().map(robot_scope_to_proto),
+        conditions: sq.conditions.as_ref().map(condition_to_proto),
+        facet: sq.facet.as_ref().map(facet_to_proto),
+        time_range: sq.time_range.as_ref().map(time_range_to_proto),
+        time_basis: sq
+            .time_basis
+            .map(|tb| time_basis_to_proto(tb) as i32)
+            .unwrap_or(0),
+        order_by: sq.order_by.as_ref().map(order_by_to_proto),
+        limit: sq.limit,
+        output_format: sq
+            .output_format
+            .map(|f| output_format_to_proto(f) as i32)
+            .unwrap_or(0),
+        baseline: sq.baseline.as_ref().map(baseline_to_proto),
+    }
+}
+
+fn pipeline_query_to_proto(pq: &ast::PipelineQuery) -> pb::PipelineQuery {
+    pb::PipelineQuery {
+        stages: pq.stages.iter().map(pipeline_stage_to_proto).collect(),
+    }
+}
+
+fn pipeline_stage_to_proto(stage: &ast::PipelineStage) -> pb::PipelineStage {
+    let stage_oneof = match stage {
+        ast::PipelineStage::From(ds) => pb::pipeline_stage::Stage::From(data_source_to_proto(ds)),
+        ast::PipelineStage::Select(sels) => pb::pipeline_stage::Stage::Select(pb::SelectStage {
+            selections: sels.iter().map(selection_to_proto).collect(),
+        }),
+        ast::PipelineStage::Where(cond) => {
+            pb::pipeline_stage::Stage::Where(condition_to_proto(cond))
+        }
+        ast::PipelineStage::Facet(f) => pb::pipeline_stage::Stage::Facet(facet_to_proto(f)),
+        ast::PipelineStage::Since(tr) => pb::pipeline_stage::Stage::Since(time_range_to_proto(tr)),
+        ast::PipelineStage::Using(tb) => {
+            pb::pipeline_stage::Stage::Using(time_basis_to_proto(*tb) as i32)
+        }
+        ast::PipelineStage::OrderBy(ob) => {
+            pb::pipeline_stage::Stage::OrderBy(order_by_to_proto(ob))
+        }
+        ast::PipelineStage::Limit(n) => pb::pipeline_stage::Stage::Limit(*n),
+        ast::PipelineStage::Format(f) => {
+            pb::pipeline_stage::Stage::Format(output_format_to_proto(*f) as i32)
+        }
+        ast::PipelineStage::CompareTo(b) => {
+            pb::pipeline_stage::Stage::CompareTo(baseline_to_proto(b))
+        }
+        ast::PipelineStage::ForRobot(r) => {
+            pb::pipeline_stage::Stage::ForRobot(robot_scope_to_proto(r))
+        }
+        ast::PipelineStage::CompoundClause(cc) => {
+            pb::pipeline_stage::Stage::CompoundClause(compound_clause_to_proto(cc))
+        }
+    };
+    pb::PipelineStage {
+        stage: Some(stage_oneof),
+    }
+}
+
+fn compound_query_to_proto(cq: &ast::CompoundQuery) -> pb::CompoundQuery {
+    pb::CompoundQuery {
+        clause: Some(compound_clause_to_proto(&cq.clause)),
+        robot_scope: cq.robot_scope.as_ref().map(robot_scope_to_proto),
+        time_range: cq.time_range.as_ref().map(time_range_to_proto),
+        time_basis: cq
+            .time_basis
+            .map(|tb| time_basis_to_proto(tb) as i32)
+            .unwrap_or(0),
+        conditions: cq.conditions.as_ref().map(condition_to_proto),
+        facet: cq.facet.as_ref().map(facet_to_proto),
+        order_by: cq.order_by.as_ref().map(order_by_to_proto),
+        limit: cq.limit,
+        output_format: cq
+            .output_format
+            .map(|f| output_format_to_proto(f) as i32)
+            .unwrap_or(0),
+        baseline: cq.baseline.as_ref().map(baseline_to_proto),
+    }
+}
+
+// ===========================================================================
+// Component converters
+// ===========================================================================
+
+fn data_source_to_proto(ds: &ast::DataSource) -> pb::DataSource {
+    let source = match ds {
+        ast::DataSource::Logs => pb::data_source::Source::Type(pb::DataSourceType::Logs as i32),
+        ast::DataSource::SystemLogs => {
+            pb::data_source::Source::Type(pb::DataSourceType::SystemLogs as i32)
+        }
+        ast::DataSource::Traces => pb::data_source::Source::Type(pb::DataSourceType::Traces as i32),
+        ast::DataSource::Metrics => {
+            pb::data_source::Source::Type(pb::DataSourceType::Metrics as i32)
+        }
+        ast::DataSource::Diagnostics => {
+            pb::data_source::Source::Type(pb::DataSourceType::Diagnostics as i32)
+        }
+        ast::DataSource::Topics => pb::data_source::Source::Type(pb::DataSourceType::Topics as i32),
+        ast::DataSource::Tf => pb::data_source::Source::Type(pb::DataSourceType::Tf as i32),
+        ast::DataSource::Heartbeats => {
+            pb::data_source::Source::Type(pb::DataSourceType::Heartbeats as i32)
+        }
+        ast::DataSource::Recordings => {
+            pb::data_source::Source::Type(pb::DataSourceType::Recordings as i32)
+        }
+        ast::DataSource::Events => pb::data_source::Source::Type(pb::DataSourceType::Events as i32),
+        ast::DataSource::TopicAlias(alias) => {
+            let alias_type = match alias {
+                ast::TopicAlias::Odom => pb::TopicAliasType::Odom,
+                ast::TopicAlias::JointStates => pb::TopicAliasType::JointStates,
+                ast::TopicAlias::Battery => pb::TopicAliasType::Battery,
+                ast::TopicAlias::CmdVel => pb::TopicAliasType::CmdVel,
+                ast::TopicAlias::Imu => pb::TopicAliasType::Imu,
+            };
+            pb::data_source::Source::TopicAlias(alias_type as i32)
+        }
+    };
+    pb::DataSource {
+        source: Some(source),
+    }
+}
+
+fn selection_to_proto(sel: &ast::Selection) -> pb::Selection {
+    let selection = match sel {
+        ast::Selection::Star => pb::selection::Selection::Star(true),
+        ast::Selection::Field(name) => pb::selection::Selection::Field(name.clone()),
+        ast::Selection::Aggregation(agg) => {
+            pb::selection::Selection::Aggregation(aggregation_to_proto(agg))
+        }
+        ast::Selection::Aliased { expr, alias } => {
+            pb::selection::Selection::Aliased(Box::new(pb::AliasedSelection {
+                expr: Some(Box::new(selection_to_proto(expr))),
+                alias: alias.clone(),
+            }))
+        }
+    };
+    pb::Selection {
+        selection: Some(selection),
+    }
+}
+
+fn aggregation_to_proto(agg: &ast::AggregationCall) -> pb::AggregationCall {
+    let function = match agg.function {
+        ast::AggregationFn::Count => pb::AggregationFunction::Count,
+        ast::AggregationFn::Sum => pb::AggregationFunction::Sum,
+        ast::AggregationFn::Avg => pb::AggregationFunction::Avg,
+        ast::AggregationFn::Min => pb::AggregationFunction::Min,
+        ast::AggregationFn::Max => pb::AggregationFunction::Max,
+        ast::AggregationFn::Percentile => pb::AggregationFunction::Percentile,
+        ast::AggregationFn::Stddev => pb::AggregationFunction::Stddev,
+        ast::AggregationFn::Rate => pb::AggregationFunction::Rate,
+        ast::AggregationFn::Delta => pb::AggregationFunction::Delta,
+        ast::AggregationFn::Derivative => pb::AggregationFunction::Derivative,
+        ast::AggregationFn::MovingAvg => pb::AggregationFunction::MovingAvg,
+        ast::AggregationFn::TopicRate => pb::AggregationFunction::TopicRate,
+        ast::AggregationFn::NodeStatus => pb::AggregationFunction::NodeStatus,
+        ast::AggregationFn::Expected => pb::AggregationFunction::Expected,
+        ast::AggregationFn::ActionSuccessRate => pb::AggregationFunction::ActionSuccessRate,
+        ast::AggregationFn::Uptime => pb::AggregationFunction::Uptime,
+        ast::AggregationFn::ApproxCountDistinct => pb::AggregationFunction::ApproxCountDistinct,
+        ast::AggregationFn::ApproxPercentile => pb::AggregationFunction::ApproxPercentile,
+    };
+    pb::AggregationCall {
+        function: function as i32,
+        args: agg.args.iter().map(expr_to_proto).collect(),
+    }
+}
+
+fn expr_to_proto(expr: &ast::Expr) -> pb::Expr {
+    let expr_oneof = match expr {
+        ast::Expr::Field(name) => pb::expr::Expr::Field(name.clone()),
+        ast::Expr::Literal(lit) => pb::expr::Expr::Literal(literal_to_proto(lit)),
+        ast::Expr::UnitValue(uv) => pb::expr::Expr::UnitValue(pb::UnitValue {
+            raw_value: uv.raw_value,
+            unit: uv.unit.clone(),
+            si_value: uv.si_value,
+            si_unit: uv.si_unit.clone(),
+        }),
+        ast::Expr::Aggregation(agg) => pb::expr::Expr::Aggregation(aggregation_to_proto(agg)),
+        ast::Expr::FieldAccess { base, key } => pb::expr::Expr::FieldAccess(pb::FieldAccess {
+            base: base.clone(),
+            key: key.clone(),
+        }),
+        ast::Expr::BinaryOp { left, op, right } => {
+            let op_proto = match op {
+                ast::ArithmeticOp::Add => pb::ArithmeticOp::Add,
+                ast::ArithmeticOp::Sub => pb::ArithmeticOp::Sub,
+                ast::ArithmeticOp::Mul => pb::ArithmeticOp::Mul,
+                ast::ArithmeticOp::Div => pb::ArithmeticOp::Div,
+            };
+            pb::expr::Expr::BinaryOp(Box::new(pb::BinaryOp {
+                left: Some(Box::new(expr_to_proto(left))),
+                op: op_proto as i32,
+                right: Some(Box::new(expr_to_proto(right))),
+            }))
+        }
+    };
+    pb::Expr {
+        expr: Some(expr_oneof),
+    }
+}
+
+fn literal_to_proto(lit: &ast::Literal) -> pb::Literal {
+    let value = match lit {
+        ast::Literal::Integer(n) => pb::literal::Value::Integer(*n),
+        ast::Literal::Float(f) => pb::literal::Value::Float(*f),
+        ast::Literal::String(s) => pb::literal::Value::StringValue(s.clone()),
+        ast::Literal::Boolean(b) => pb::literal::Value::Boolean(*b),
+        ast::Literal::Null => pb::literal::Value::Null(true),
+    };
+    pb::Literal { value: Some(value) }
+}
+
+fn condition_to_proto(cond: &ast::Condition) -> pb::Condition {
+    let cond_oneof = match cond {
+        ast::Condition::Comparison { left, op, right } => {
+            let op_proto = match op {
+                ast::ComparisonOp::Eq => pb::ComparisonOp::Eq,
+                ast::ComparisonOp::Neq => pb::ComparisonOp::Neq,
+                ast::ComparisonOp::Lt => pb::ComparisonOp::Lt,
+                ast::ComparisonOp::Gt => pb::ComparisonOp::Gt,
+                ast::ComparisonOp::Lte => pb::ComparisonOp::Lte,
+                ast::ComparisonOp::Gte => pb::ComparisonOp::Gte,
+            };
+            pb::condition::Condition::Comparison(pb::Comparison {
+                left: Some(expr_to_proto(left)),
+                op: op_proto as i32,
+                right: Some(expr_to_proto(right)),
+            })
+        }
+        ast::Condition::And(a, b) => pb::condition::Condition::And(Box::new(pb::LogicalOp {
+            left: Some(Box::new(condition_to_proto(a))),
+            right: Some(Box::new(condition_to_proto(b))),
+        })),
+        ast::Condition::Or(a, b) => pb::condition::Condition::Or(Box::new(pb::LogicalOp {
+            left: Some(Box::new(condition_to_proto(a))),
+            right: Some(Box::new(condition_to_proto(b))),
+        })),
+        ast::Condition::Not(inner) => {
+            pb::condition::Condition::Not(Box::new(condition_to_proto(inner)))
+        }
+        ast::Condition::IsNull(expr) => pb::condition::Condition::IsNull(expr_to_proto(expr)),
+        ast::Condition::IsNotNull(expr) => pb::condition::Condition::IsNotNull(expr_to_proto(expr)),
+        ast::Condition::In { expr, values } => pb::condition::Condition::InExpr(pb::InExpr {
+            expr: Some(expr_to_proto(expr)),
+            values: values.iter().map(expr_to_proto).collect(),
+        }),
+        ast::Condition::Like { expr, pattern } => pb::condition::Condition::Like(pb::LikeExpr {
+            expr: Some(expr_to_proto(expr)),
+            pattern: pattern.clone(),
+        }),
+        ast::Condition::Between { expr, low, high } => {
+            pb::condition::Condition::Between(pb::BetweenExpr {
+                expr: Some(expr_to_proto(expr)),
+                low: Some(expr_to_proto(low)),
+                high: Some(expr_to_proto(high)),
+            })
+        }
+    };
+    pb::Condition {
+        condition: Some(cond_oneof),
+    }
+}
+
+fn time_range_to_proto(tr: &ast::TimeRange) -> pb::TimeRange {
+    let range = match tr {
+        ast::TimeRange::Since(expr) => pb::time_range::Range::Since(time_expr_to_proto(expr)),
+        ast::TimeRange::Between { start, end } => pb::time_range::Range::Between(pb::BetweenTime {
+            start: Some(time_expr_to_proto(start)),
+            end: Some(time_expr_to_proto(end)),
+        }),
+    };
+    pb::TimeRange { range: Some(range) }
+}
+
+fn time_expr_to_proto(expr: &ast::TimeExpr) -> pb::TimeExpr {
+    let expr_oneof = match expr {
+        ast::TimeExpr::Relative(rt) => pb::time_expr::Expr::Relative(pb::RelativeTime {
+            amount: rt.amount,
+            unit: rt.unit.clone(),
+        }),
+        ast::TimeExpr::Absolute(ts) => pb::time_expr::Expr::Absolute(ts.clone()),
+        ast::TimeExpr::Epoch(epoch) => {
+            let precision = match epoch {
+                ast::UnixEpoch::Seconds(v) => pb::unix_epoch::Precision::Seconds(*v),
+                ast::UnixEpoch::Milliseconds(v) => pb::unix_epoch::Precision::Milliseconds(*v),
+                ast::UnixEpoch::Nanoseconds(v) => pb::unix_epoch::Precision::Nanoseconds(*v),
+            };
+            pb::time_expr::Expr::Epoch(pb::UnixEpoch {
+                precision: Some(precision),
+            })
+        }
+        ast::TimeExpr::Anchor(anchor) => {
+            let anchor_proto = match anchor {
+                ast::LifecycleAnchor::LastDeployment => pb::LifecycleAnchor::LastDeployment,
+                ast::LifecycleAnchor::LastRobotRestart => pb::LifecycleAnchor::LastRobotRestart,
+                ast::LifecycleAnchor::LastActionFailure => pb::LifecycleAnchor::LastActionFailure,
+                ast::LifecycleAnchor::LastTopicDrop => pb::LifecycleAnchor::LastTopicDrop,
+                ast::LifecycleAnchor::LastDiagnosticWarning => {
+                    pb::LifecycleAnchor::LastDiagnosticWarning
+                }
+            };
+            pb::time_expr::Expr::Anchor(anchor_proto as i32)
+        }
+    };
+    pb::TimeExpr {
+        expr: Some(expr_oneof),
+    }
+}
+
+fn robot_scope_to_proto(scope: &ast::RobotScope) -> pb::RobotScope {
+    let scope_oneof = match scope {
+        ast::RobotScope::Single(id) => pb::robot_scope::Scope::RobotId(id.clone()),
+        ast::RobotScope::Fleet => pb::robot_scope::Scope::Fleet(true),
+    };
+    pb::RobotScope {
+        scope: Some(scope_oneof),
+    }
+}
+
+fn facet_to_proto(f: &ast::FacetClause) -> pb::FacetClause {
+    pb::FacetClause {
+        dimension: f.dimension.clone(),
+    }
+}
+
+fn order_by_to_proto(ob: &ast::OrderBy) -> pb::OrderBy {
+    let dir = match ob.direction {
+        ast::SortDirection::Asc => pb::SortDirection::Asc,
+        ast::SortDirection::Desc => pb::SortDirection::Desc,
+    };
+    pb::OrderBy {
+        field: ob.field.clone(),
+        direction: dir as i32,
+    }
+}
+
+fn time_basis_to_proto(tb: ast::TimeBasis) -> pb::TimeBasis {
+    match tb {
+        ast::TimeBasis::RosTime => pb::TimeBasis::RosTime,
+        ast::TimeBasis::WallTime => pb::TimeBasis::WallTime,
+    }
+}
+
+fn output_format_to_proto(f: ast::OutputFormat) -> pb::OutputFormat {
+    match f {
+        ast::OutputFormat::Table => pb::OutputFormat::Table,
+        ast::OutputFormat::Timeseries => pb::OutputFormat::Timeseries,
+        ast::OutputFormat::Scalar => pb::OutputFormat::Scalar,
+        ast::OutputFormat::TraceTree => pb::OutputFormat::TraceTree,
+        ast::OutputFormat::Graph => pb::OutputFormat::Graph,
+        ast::OutputFormat::Path => pb::OutputFormat::Path,
+    }
+}
+
+fn baseline_to_proto(b: &ast::Baseline) -> pb::Baseline {
+    let baseline = match b {
+        ast::Baseline::LastWeek => pb::baseline::Baseline::LastWeek(true),
+        ast::Baseline::Fleet => pb::baseline::Baseline::Fleet(true),
+        ast::Baseline::Robot(id) => pb::baseline::Baseline::RobotId(id.clone()),
+        ast::Baseline::LastDeployment => pb::baseline::Baseline::LastDeployment(true),
+        ast::Baseline::CompareRobots => pb::baseline::Baseline::CompareRobots(true),
+    };
+    pb::Baseline {
+        baseline: Some(baseline),
+    }
+}
+
+fn compound_clause_to_proto(cc: &ast::CompoundClause) -> pb::CompoundClause {
+    let clause = match cc {
+        ast::CompoundClause::During {
+            inner_source,
+            inner_conditions,
+            inner_time_range,
+        } => pb::compound_clause::Clause::During(pb::DuringClause {
+            inner_source: Some(data_source_to_proto(inner_source)),
+            inner_conditions: inner_conditions.as_ref().map(condition_to_proto),
+            inner_time_range: inner_time_range.as_ref().map(time_range_to_proto),
+        }),
+        ast::CompoundClause::MessageJourney { trace_id } => {
+            pb::compound_clause::Clause::MessageJourney(pb::MessageJourneyClause {
+                trace_id: trace_id.clone(),
+            })
+        }
+        ast::CompoundClause::MessagePaths { topic } => {
+            pb::compound_clause::Clause::MessagePaths(pb::MessagePathsClause {
+                topic: topic.clone(),
+            })
+        }
+        ast::CompoundClause::MessagePath {
+            from_topic,
+            to_node,
+            show,
+        } => pb::compound_clause::Clause::MessagePath(pb::MessagePathClause {
+            from_topic: from_topic.clone(),
+            to_node: to_node.clone(),
+            show: show.clone().unwrap_or_default(),
+        }),
+        ast::CompoundClause::Trace { trace_id } => {
+            pb::compound_clause::Clause::Trace(pb::TraceClause {
+                trace_id: trace_id.clone(),
+            })
+        }
+        ast::CompoundClause::ShowTraceBreakdown => {
+            pb::compound_clause::Clause::ShowTraceBreakdown(true)
+        }
+        ast::CompoundClause::Health => pb::compound_clause::Clause::Health(true),
+        ast::CompoundClause::Anomaly { field, compared_to } => {
+            pb::compound_clause::Clause::Anomaly(pb::AnomalyClause {
+                field: field.clone(),
+                compared_to: compared_to.as_ref().map(baseline_to_proto),
+            })
+        }
+        ast::CompoundClause::PathDeviation { show } => {
+            pb::compound_clause::Clause::PathDeviation(pb::PathDeviationClause {
+                show: show.clone().unwrap_or_default(),
+            })
+        }
+        ast::CompoundClause::Correlate { with_source } => {
+            pb::compound_clause::Clause::Correlate(pb::CorrelateClause {
+                with_source: Some(data_source_to_proto(with_source)),
+            })
+        }
+        ast::CompoundClause::ShowRecording => pb::compound_clause::Clause::ShowRecording(true),
+    };
+    pb::CompoundClause {
+        clause: Some(clause),
+    }
+}
+
+// ===========================================================================
+// Error conversion
+// ===========================================================================
+
+pub fn error_to_proto(err: &ROSQLError) -> pb::ParseErrorDetail {
+    match err {
+        ROSQLError::ParseError {
+            message,
+            location,
+            suggestion,
+        } => pb::ParseErrorDetail {
+            message: message.clone(),
+            location: Some(source_location_to_proto(location)),
+            suggestion: suggestion.clone().unwrap_or_default(),
+        },
+        other => pb::ParseErrorDetail {
+            message: other.to_string(),
+            location: None,
+            suggestion: String::new(),
+        },
+    }
+}
+
+pub fn source_location_to_proto(loc: &SourceLocation) -> pb::SourceLocation {
+    pb::SourceLocation {
+        line: loc.line as u32,
+        column: loc.column as u32,
+        offset: loc.offset as u32,
+    }
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parse;
+
+    #[test]
+    fn convert_basic_select() {
+        let ast = parse("SELECT * FROM logs").unwrap();
+        let proto = query_to_proto(&ast);
+        assert!(proto.query.is_some());
+        match proto.query.unwrap() {
+            pb::rosql_query::Query::Standard(sq) => {
+                assert_eq!(sq.selections.len(), 1);
+                assert!(sq.data_source.is_some());
+            }
+            _ => panic!("expected Standard"),
+        }
+    }
+
+    #[test]
+    fn convert_pipeline() {
+        let ast = parse("FROM traces | WHERE duration > 500 ms | FACET robot_id").unwrap();
+        let proto = query_to_proto(&ast);
+        match proto.query.unwrap() {
+            pb::rosql_query::Query::Pipeline(pq) => {
+                assert_eq!(pq.stages.len(), 3);
+            }
+            _ => panic!("expected Pipeline"),
+        }
+    }
+
+    #[test]
+    fn convert_compound_health() {
+        let ast = parse("HEALTH() FOR ROBOT 'robot_42' SINCE 1 hour ago").unwrap();
+        let proto = query_to_proto(&ast);
+        match proto.query.unwrap() {
+            pb::rosql_query::Query::Compound(cq) => {
+                assert!(cq.clause.is_some());
+                assert!(cq.robot_scope.is_some());
+                assert!(cq.time_range.is_some());
+            }
+            _ => panic!("expected Compound"),
+        }
+    }
+
+    #[test]
+    fn convert_unit_value() {
+        let ast = parse("FROM traces WHERE duration > 500 ms").unwrap();
+        let proto = query_to_proto(&ast);
+        // Verify the unit value made it through
+        match proto.query.unwrap() {
+            pb::rosql_query::Query::Standard(sq) => {
+                assert!(sq.conditions.is_some());
+            }
+            _ => panic!("expected Standard"),
+        }
+    }
+
+    #[test]
+    fn convert_error() {
+        let err = ROSQLError::ParseError {
+            message: "unexpected token".into(),
+            location: SourceLocation {
+                line: 1,
+                column: 5,
+                offset: 4,
+            },
+            suggestion: Some("SELECT".into()),
+        };
+        let proto = error_to_proto(&err);
+        assert_eq!(proto.message, "unexpected token");
+        assert_eq!(proto.suggestion, "SELECT");
+        let loc = proto.location.unwrap();
+        assert_eq!(loc.line, 1);
+        assert_eq!(loc.column, 5);
+    }
+
+    #[test]
+    fn convert_lifecycle_anchor() {
+        let ast = parse("FROM traces SINCE last action failure").unwrap();
+        let proto = query_to_proto(&ast);
+        match proto.query.unwrap() {
+            pb::rosql_query::Query::Standard(sq) => {
+                assert!(sq.time_range.is_some());
+            }
+            _ => panic!("expected Standard"),
+        }
+    }
+
+    #[test]
+    fn convert_message_journey() {
+        let ast = parse("MESSAGE JOURNEY FOR TRACE 'abc123'").unwrap();
+        let proto = query_to_proto(&ast);
+        match proto.query.unwrap() {
+            pb::rosql_query::Query::Compound(cq) => {
+                let clause = cq.clause.unwrap().clause.unwrap();
+                match clause {
+                    pb::compound_clause::Clause::MessageJourney(mj) => {
+                        assert_eq!(mj.trace_id, "abc123");
+                    }
+                    _ => panic!("expected MessageJourney"),
+                }
+            }
+            _ => panic!("expected Compound"),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,8 @@
 //! drivers, the WASM frontend module, and the gRPC parser sidecar.
 
 pub mod ast;
+pub mod completions;
+pub mod convert;
 pub mod drivers;
 pub mod error;
 pub mod lexer;
@@ -12,6 +14,9 @@ pub mod parser;
 pub mod proto;
 pub mod span;
 pub mod units;
+
+#[cfg(feature = "wasm")]
+pub mod wasm;
 
 // Public convenience re-exports
 pub use ast::{Query, ROSQLQuery};

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,0 +1,107 @@
+//! WASM exports for frontend parse/validate/completions.
+//!
+//! Feature-gated behind `--features wasm`. Compiled to WASM via
+//! `wasm-pack build --target web` or `cargo build --target wasm32-unknown-unknown --features wasm`.
+//!
+//! Parse-only — no driver/execution code is included in the WASM bundle.
+
+use wasm_bindgen::prelude::*;
+
+use crate::completions;
+
+/// Parse a ROSQL query string into a typed AST.
+///
+/// Returns a JSON object:
+/// - `{ ok: true, ast: { ... } }` on success
+/// - `{ ok: false, error: { message, line, column, suggestion } }` on failure
+#[wasm_bindgen]
+pub fn parse(query: &str) -> JsValue {
+    match crate::parser::parse(query) {
+        Ok(ast) => {
+            let result = serde_json::json!({
+                "ok": true,
+                "ast": serde_json::to_value(&ast).unwrap_or(serde_json::Value::Null),
+            });
+            serde_wasm_bindgen::to_value(&result).unwrap_or(JsValue::NULL)
+        }
+        Err(errors) => {
+            let error = &errors[0];
+            let result = match error {
+                crate::error::ROSQLError::ParseError {
+                    message,
+                    location,
+                    suggestion,
+                } => serde_json::json!({
+                    "ok": false,
+                    "error": {
+                        "message": message,
+                        "line": location.line,
+                        "column": location.column,
+                        "suggestion": suggestion,
+                    }
+                }),
+                other => serde_json::json!({
+                    "ok": false,
+                    "error": {
+                        "message": other.to_string(),
+                    }
+                }),
+            };
+            serde_wasm_bindgen::to_value(&result).unwrap_or(JsValue::NULL)
+        }
+    }
+}
+
+/// Validate a ROSQL query string without full AST construction.
+///
+/// Returns a JSON object:
+/// `{ valid: bool, errors: [...], warnings: [...] }`
+#[wasm_bindgen]
+pub fn validate(query: &str) -> JsValue {
+    match crate::parser::parse(query) {
+        Ok(_) => {
+            let result = serde_json::json!({
+                "valid": true,
+                "errors": [],
+                "warnings": [],
+            });
+            serde_wasm_bindgen::to_value(&result).unwrap_or(JsValue::NULL)
+        }
+        Err(errors) => {
+            let error_list: Vec<serde_json::Value> = errors
+                .iter()
+                .map(|e| match e {
+                    crate::error::ROSQLError::ParseError {
+                        message,
+                        location,
+                        suggestion,
+                    } => serde_json::json!({
+                        "message": message,
+                        "line": location.line,
+                        "column": location.column,
+                        "suggestion": suggestion,
+                    }),
+                    other => serde_json::json!({
+                        "message": other.to_string(),
+                    }),
+                })
+                .collect();
+
+            let result = serde_json::json!({
+                "valid": false,
+                "errors": error_list,
+                "warnings": [],
+            });
+            serde_wasm_bindgen::to_value(&result).unwrap_or(JsValue::NULL)
+        }
+    }
+}
+
+/// Get autocomplete suggestions at a cursor position.
+///
+/// Returns an array of `{ label, detail, kind }` objects.
+#[wasm_bindgen]
+pub fn get_completions(query: &str, cursor_pos: usize) -> JsValue {
+    let completions = completions::get_completions(query, cursor_pos);
+    serde_wasm_bindgen::to_value(&completions).unwrap_or(JsValue::NULL)
+}


### PR DESCRIPTION
Implement the three remaining usage modes for ROSQL (GH #4):

WASM (--features wasm):
- parse(), validate(), get_completions() via wasm-bindgen
- Parse-only — no driver/execution code in WASM bundle
- Uses serde-wasm-bindgen for JS serialization

gRPC server + CLI (--features server):
- rosql-parser binary with subcommands: serve, parse, validate, completions
- gRPC server on Unix socket implementing ROSQLParserService
- CLI mode outputs JSON to stdout, reads from arg or stdin

Completions engine (src/completions.rs):
- Context-aware suggestions based on cursor position
- Covers data sources, fields, time expressions, units, keywords, baselines, output formats, lifecycle anchors

AST conversion layer (src/convert.rs):
- Full native AST → proto conversion for all query types
- Error → proto conversion with source location

Also:
- Rename feature robotops-backend → server (open-source friendly)
- Set rust-version = "1.80" (MSRV for std::sync::LazyLock)
- build.rs conditionally uses tonic-build when server feature enabled
- Update README with usage modes, feature flags, CLI docs
- Update CONTRIBUTING with prerequisites, build variants, proto workflow

258 tests pass, clippy clean, all three build targets compile.