### PR TITLE
fix: pass crates-io-auth token to cargo publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,9 +99,12 @@ jobs:
         run: sudo apt-get install -y protobuf-compiler
 
       - name: Authenticate with crates.io (OIDC trusted publishing)
+        id: crates-io-auth
         uses: rust-lang/crates-io-auth-action@v1
 
       - name: Publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
         run: cargo publish --no-verify --allow-dirty
 
   publish-npm:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.4] - 2026-03-25
+
+### Fixed
+
+- crates.io: capture auth action output token and pass via CARGO_REGISTRY_TOKEN
+
 ## [0.1.3] - 2026-03-25
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3172,7 +3172,7 @@ dependencies = [
 
 [[package]]
 name = "rosql"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "async-trait",
  "aws-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ exclude = ["examples"]
 
 [package]
 name = "rosql"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 rust-version = "1.80"
 license = "Apache-2.0"


### PR DESCRIPTION
The crates-io-auth-action outputs a token that must be explicitly passed to cargo publish via CARGO_REGISTRY_TOKEN. It doesn't set the env var automatically.

Bump to 0.1.4.