### PR TITLE
feat(#63): ENRICH WITH, TIMESERIES, SHOW TOPICS/NODES/NODE GRAPH — v0…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,74 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.2] - 2026-04-09
+
+### Added
+
+- **TIMESERIES** — time-bucketed aggregation clause: `TIMESERIES 5 min` in standard and pipeline queries
+  - Compiles to `time_bucket` (DuckDB) / `date_bin` (PostgreSQL) / `FROM_UNIXTIME(... DIV ...)` (MySQL)
+  - Automatically prepends `time_bucket` to SELECT, adds to GROUP BY, defaults `ORDER BY time_bucket ASC`
+  - Composes with `FACET`: `GROUP BY time_bucket, <facet_col>`
+  - Exempt from the default `LIMIT 100` safety cap
+- **ENRICH WITH** — cross-source data correlation in two-phase execution
+  - `ENRICH WITH <source> [LIMIT N] [SAMPLE FULL]` appends enrichment rows to each primary result row
+  - Default 50 enrichment rows per join key; overridable with `LIMIT N`; `SAMPLE FULL` skips the cap
+  - Multiple enrichments supported: `ENRICH WITH logs LIMIT 20 ENRICH WITH metrics`
+  - Executor uses a window-function SQL pattern (`ROW_NUMBER OVER PARTITION BY`) to respect per-row limits
+  - Enrichment rows merged as `_enriched[source]` JSON in result rows; metadata carries `EnrichmentMeta`
+- **SHOW TOPICS** — active ROS2 topic summary from span attributes (topic_name, message_type, avg_rate_hz, publishers, subscribers, last_message_age_ms)
+- **SHOW NODES** — active ROS2 node summary (node_name, topics_published, topics_subscribed, error_count, last_seen)
+- **SHOW NODE GRAPH** — topic/node edges for graph visualisation (source_node, topic, target_node); all three accept `FOR ROBOT` and `SINCE` scoping
+- **Completions**: `SHOW TOPICS`, `SHOW NODES`, `SHOW NODE GRAPH`, `TIMESERIES`, `ENRICH WITH` added to autocomplete; `SHOW <cursor>` context now suggests SHOW subcommands
+- **Bug fix**: `SINCE 30 min ago` now parses correctly — short-form SI unit abbreviations (`min`, `h`, `s`, `ms`, `ns`, `d`, `w`) were missing from the time-unit recogniser
+- **Dialect**: `json_access_text()` wraps JSON extraction in `CAST(... AS VARCHAR)` for DuckDB to avoid type-cast errors in WHERE/ORDER BY/DISTINCT contexts; `time_bucket()` method for all three dialects
+
+### Changed
+
+- `CompileResult` carries `enrichments: Vec<EnrichmentPlan>` (non-breaking; empty for queries without `ENRICH WITH`)
+- `ResultMetadata` carries `enrichment_metadata: Vec<EnrichmentMeta>` (non-breaking; empty by default)
+
+## [0.4.1] - 2026-04-09
+
+### Added
+
+- **Universal scoping phase 2+3**: `MESSAGE FLOW FROM TOPIC '...' [TO NODE|TOPIC '...']` replaces removed `MESSAGE PATHS`/`MESSAGE PATH`; compiles to a `msg_flow` recursive CTE
+- **TRACE recursive CTE**: `TRACE 'id'` now walks `parent_span_id → span_id` with `WITH RECURSIVE trace_tree`; seeds the CTE with active scope filters
+- **SHOW DEPLOYMENTS**: `SHOW DEPLOYMENTS [FOR ROBOT '...'] [SINCE ...]` — deployment history grouped by version + environment
+- **SHOW SPAN SUMMARY**: latency report (span_name, count, avg/max duration) grouped by span name
+- **SHOW PLANS**: navigation plan spans filtered on `ros.plan.id IS NOT NULL`; accepts `FOR TRACE 'id'` or `FOR ROBOT '...'`
+- **COMPARE TO VERSION**: `COMPARE TO VERSION '1.2.3'` baseline; `COMPARE VERSION '...' VERSION '...'` pair baseline
+
+### Removed
+
+- `MESSAGE JOURNEY` — parse now returns a descriptive `ParseError` pointing to `TRACE`
+- `MESSAGE PATHS` / `MESSAGE PATH` — parse now returns descriptive `ParseError` messages pointing to `MESSAGE FLOW`
+
+### Changed
+
+- Docs (command-reference, cookbook, schema-reference) updated in both `docs/` and `versioned_docs/version-0.4/`
+
+## [0.4.0] - 2026-04-09
+
+### Added
+
+- **6 aggregation functions** with real SQL compilation: `TOPIC_RATE`, `ACTION_SUCCESS_RATE`, `MOVING_AVG`, `DERIVATIVE`, `APPROX_COUNT_DISTINCT`, `APPROX_PERCENTILE` — all dialect-aware (PostgreSQL / DuckDB / MySQL)
+- **`OFFSET` keyword**: `LIMIT N OFFSET M` and pipeline `| OFFSET N`
+- **Default `LIMIT 100` safety cap**: applied to all queries except scalar aggregates, `FACET`, `TRACE`, `MESSAGE FLOW`; `default_limit_applied` flag in `ResultMetadata`
+- **`ExecOptions::max_rows`** enforced at execution time
+- **`ROSQLError::NotImplemented { feature, message }`** variant with workaround guidance
+- **Universal scoping phase 1**: `QueryScope` struct; `FOR VERSION '...'`, `FOR ENVIRONMENT '...'`, `FOR SESSION '...'` filter on resource attributes
+
+### Changed
+
+- `COMPARE VERSION` pair baseline compares two robot software versions side by side
+- `ALERT`/`DEFINE` reserved syntax errors now surface platform-specific guidance
+
+### Gated (NotImplemented)
+
+- 5 aggregations: `NODE_STATUS`, `EXPECTED`, `UPTIME`, `RATE`, `DELTA` — each returns an actionable workaround
+- 6 compound clauses: `HEALTH`, `ANOMALY`, `PATH DEVIATION`, `CORRELATE WITH`, `SHOW RECORDING`, `SHOW TRACE_BREAKDOWN`
+
 ## [0.3.2] - 2026-03-26
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3253,7 +3253,7 @@ dependencies = [
 
 [[package]]
 name = "rosql"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "async-trait",
  "aws-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ exclude = ["examples"]
 
 [package]
 name = "rosql"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 rust-version = "1.80"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -220,20 +220,63 @@ DURING(
 )
 SINCE yesterday
 
--- Message causality graph
-MESSAGE JOURNEY FOR TRACE 'abc123def456'
+-- Time-bucketed error rate dashboard (TIMESERIES)
+SELECT COUNT(*) AS errors FROM traces WHERE status = 'ERROR'
+TIMESERIES 5 min
+SINCE 1 hour ago
+FACET robot_id
 
--- Robot health assessment
-HEALTH() FOR ROBOT 'robot_42' SINCE 30 minutes ago
+-- Enrich failed navigation traces with log context (ENRICH WITH)
+SELECT * FROM traces
+WHERE status = 'ERROR' AND action_name = '/navigate_to_pose'
+SINCE 1 hour ago
+ENRICH WITH logs LIMIT 20
+
+-- System topology: active topics and nodes
+SHOW TOPICS FOR ROBOT 'robot_42' SINCE 30 minutes ago
+SHOW NODES FOR ROBOT 'robot_42' SINCE 30 minutes ago
+SHOW NODE GRAPH FOR ROBOT 'robot_42' SINCE 30 minutes ago
+
+-- Trace span tree walk
+TRACE 'abc123def456'
 
 -- Pipeline syntax
 FROM traces
 | WHERE duration > 500 ms
+| TIMESERIES 1 min
 | FACET robot_id
-| COMPARE TO last week
 ```
 
 See [`examples/`](examples/) for a full walkthrough with Docker Compose, PostgreSQL fixture data, and runnable queries.
+
+### Cookbook: Investigating a failed navigation with enriched logs
+
+When a navigation action fails, the recommended workflow is:
+
+```sql
+-- 1. Find the failing trace
+SELECT trace_id, span_name, duration
+FROM traces
+WHERE status = 'ERROR' AND action_name = '/navigate_to_pose'
+SINCE 30 min ago
+ORDER BY duration DESC
+LIMIT 5
+
+-- 2. Walk the full causality chain for the worst offender
+TRACE 'your-trace-id-here'
+
+-- 3. Correlate with log output for that same window
+SELECT * FROM traces
+WHERE status = 'ERROR' AND action_name = '/navigate_to_pose'
+SINCE 30 min ago
+ENRICH WITH logs LIMIT 50
+
+-- 4. Check which topics were active during the failure
+SHOW TOPICS FOR ROBOT 'robot_42' SINCE 30 min ago
+
+-- 5. See the node graph to spot missing pub/sub edges
+SHOW NODE GRAPH FOR ROBOT 'robot_42' SINCE 30 min ago
+```
 
 ## WASM API
 

--- a/examples/queries/compound_clauses.rosql
+++ b/examples/queries/compound_clauses.rosql
@@ -60,3 +60,22 @@ SHOW SPAN SUMMARY FOR ROBOT 'robot_sim_001' SINCE 1 hour ago
 -- SHOW PLANS — navigation/behaviour plan spans for a trace
 -- ============================================================================
 SHOW PLANS FOR TRACE 'trace-002'
+
+-- ============================================================================
+-- SHOW TOPICS — list active ROS2 topics with publish rates (v0.4.2+)
+-- Aggregates span_attributes to show topic_name, message_type, avg_rate_hz,
+-- publisher/subscriber counts, and last_message_age_ms.
+-- ============================================================================
+SHOW TOPICS FOR ROBOT 'robot_sim_001' SINCE 1 hour ago
+SHOW TOPICS WHERE topic_name LIKE '/camera%' SINCE 30 minutes ago
+
+-- ============================================================================
+-- SHOW NODES — list active ROS2 nodes with pub/sub counts (v0.4.2+)
+-- ============================================================================
+SHOW NODES FOR ROBOT 'robot_sim_001' SINCE 30 minutes ago
+
+-- ============================================================================
+-- SHOW NODE GRAPH — topic/node edges for graph visualisation (v0.4.2+)
+-- Returns (source_node, topic, target_node) rows for building a network graph.
+-- ============================================================================
+SHOW NODE GRAPH FOR ROBOT 'robot_sim_001' SINCE 30 minutes ago

--- a/examples/queries/timeseries.rosql
+++ b/examples/queries/timeseries.rosql
@@ -11,3 +11,43 @@ SELECT AVG(duration) AS avg_dur, MAX(duration) AS max_dur, COUNT(*) AS total FRO
 
 -- Percentile analysis
 SELECT PERCENTILE(duration, 95) FROM traces WHERE action_name = '/navigate_to_pose'
+
+-- ============================================================================
+-- TIMESERIES — time-bucketed dashboard queries (v0.4.2+)
+-- Compiles to time_bucket/date_bin SQL with automatic GROUP BY + ORDER BY.
+-- ============================================================================
+
+-- Error rate bucketed by 5-minute windows
+SELECT COUNT(*) AS errors FROM traces WHERE status = 'ERROR' TIMESERIES 5 min SINCE 1 hour ago
+
+-- Average duration per node, bucketed hourly
+SELECT AVG(duration) AS avg_ms FROM traces TIMESERIES 1 hour SINCE 24 hours ago FACET robot_id
+
+-- CPU usage bucketed by 30-second windows (pipeline syntax)
+FROM metrics WHERE metric_name = 'cpu_usage'
+  | TIMESERIES 30 s
+  | SINCE 30 min ago
+  | FACET robot_id
+
+-- ============================================================================
+-- ENRICH WITH — cross-source data correlation (v0.4.2+)
+-- Two-phase execution: primary query runs first, then enrichment rows are
+-- fetched and merged as _enriched[source] JSON in each primary row.
+-- ============================================================================
+
+-- Enrich failed traces with the most recent 50 log lines
+SELECT * FROM traces WHERE status = 'ERROR' SINCE 1 hour ago
+ENRICH WITH logs
+
+-- Enrich navigation spans with limited log context per trace
+SELECT * FROM traces WHERE action_name = '/navigate_to_pose' SINCE 30 min ago
+ENRICH WITH logs LIMIT 10
+
+-- Enrich with full (untruncated) log sample
+SELECT * FROM traces WHERE status = 'ERROR' SINCE 6 hours ago
+ENRICH WITH logs SAMPLE FULL
+
+-- Multiple enrichments: correlate traces with both logs and metrics
+SELECT * FROM traces WHERE status = 'ERROR' SINCE 1 hour ago
+ENRICH WITH logs LIMIT 20
+ENRICH WITH metrics LIMIT 5

--- a/proto/rosql/v1/ast.proto
+++ b/proto/rosql/v1/ast.proto
@@ -32,6 +32,21 @@ message StandardQuery {
   OutputFormat output_format = 10;
   Baseline baseline = 11;
   optional uint64 offset = 12;
+  TimeseriesClause timeseries = 13;          // TIMESERIES interval
+  repeated EnrichmentClause enrichments = 14; // ENRICH WITH clauses
+}
+
+// TIMESERIES time-bucket interval.
+message TimeseriesClause {
+  UnitValue interval = 1;
+}
+
+// ENRICH WITH clause.
+message EnrichmentClause {
+  DataSource source = 1;
+  string join_key = 2;       // optional explicit join key
+  optional uint64 limit = 3; // per-row limit (default 50)
+  bool sample_full = 4;      // disable auto-downsampling
 }
 
 // Pipeline query: FROM source | WHERE ... | FACET ...
@@ -54,6 +69,8 @@ message PipelineStage {
     QueryScope for_scope = 11;
     CompoundClause compound_clause = 12;
     uint64 offset = 13;
+    TimeseriesClause timeseries = 14;   // TIMESERIES interval stage
+    EnrichmentClause enrich_with = 15;  // ENRICH WITH stage
   }
 }
 
@@ -402,6 +419,9 @@ message CompoundClause {
     bool show_deployments = 13;           // SHOW DEPLOYMENTS
     bool show_span_summary = 14;          // SHOW SPAN SUMMARY
     ShowPlansClause show_plans = 15;      // SHOW PLANS [FOR TRACE ...]
+    bool show_topics = 16;               // SHOW TOPICS
+    bool show_nodes = 17;                // SHOW NODES
+    bool show_node_graph = 18;           // SHOW NODE GRAPH
   }
 }
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -32,6 +32,8 @@ pub struct ROSQLQuery {
     pub offset: Option<u64>,
     pub output_format: Option<OutputFormat>,
     pub baseline: Option<Baseline>,
+    pub timeseries: Option<TimeseriesClause>,
+    pub enrichments: Vec<EnrichmentClause>,
 }
 
 /// Pipeline query: `FROM source | WHERE ... | FACET ...`
@@ -56,6 +58,8 @@ pub enum PipelineStage {
     CompareTo(Baseline),
     ForScope(QueryScope),
     CompoundClause(CompoundClause),
+    Timeseries(TimeseriesClause),
+    EnrichWith(EnrichmentClause),
 }
 
 /// A top-level compound query (MESSAGE FLOW, HEALTH(), TRACE, etc.).
@@ -417,6 +421,34 @@ pub enum OutputFormat {
 }
 
 // ===========================================================================
+// Timeseries
+// ===========================================================================
+
+/// TIMESERIES interval — time-bucketed aggregation.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TimeseriesClause {
+    /// The bucket width (e.g. `5 min`, `1 hour`).
+    pub interval: UnitValue,
+}
+
+// ===========================================================================
+// Enrichment
+// ===========================================================================
+
+/// ENRICH WITH clause — joins additional data into a primary query result.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EnrichmentClause {
+    /// The data source to enrich from.
+    pub source: DataSource,
+    /// Explicit join key override (None = infer from source pair).
+    pub join_key: Option<String>,
+    /// Per-primary-row row limit (default 50).
+    pub limit: Option<u64>,
+    /// Disable auto-downsampling for high-frequency topic data.
+    pub sample_full: bool,
+}
+
+// ===========================================================================
 // Baselines
 // ===========================================================================
 
@@ -496,4 +528,13 @@ pub enum CompoundClause {
 
     /// `SHOW PLANS [FOR TRACE 'trace_id'] [FOR ROBOT ...] [SINCE ...]`
     ShowPlans { trace_id: Option<String> },
+
+    /// `SHOW TOPICS [FOR ROBOT ...] [SINCE ...]`
+    ShowTopics,
+
+    /// `SHOW NODES [FOR ROBOT ...] [SINCE ...]`
+    ShowNodes,
+
+    /// `SHOW NODE GRAPH [FOR ROBOT ...] [SINCE ...]`
+    ShowNodeGraph,
 }

--- a/src/completions.rs
+++ b/src/completions.rs
@@ -70,6 +70,18 @@ pub fn get_completions(query: &str, cursor_pos: usize) -> Vec<Completion> {
         return lifecycle_anchor_completions();
     }
 
+    if upper.ends_with("TIMESERIES ") || upper.ends_with("TIMESERIES") {
+        return unit_completions();
+    }
+
+    if upper.ends_with("ENRICH WITH ") || upper.ends_with("ENRICH WITH") {
+        return data_source_completions();
+    }
+
+    if upper.ends_with("SHOW ") || upper.ends_with("SHOW") {
+        return show_completions();
+    }
+
     // After a number, suggest unit suffixes
     if trimmed.chars().last().is_some_and(|c| c.is_ascii_digit()) {
         return unit_completions();
@@ -87,14 +99,14 @@ fn query_start_completions() -> Vec<Completion> {
     vec![
         kw("SELECT", "Select specific fields"),
         kw("FROM", "Query a data source"),
-        kw("MESSAGE JOURNEY", "Trace message causality graph"),
-        kw("MESSAGE PATHS", "Find message paths for a topic"),
-        kw("MESSAGE PATH", "Find path between topic and node"),
+        kw("SHOW TOPICS", "List active ROS2 topics"),
+        kw("SHOW NODES", "List active ROS2 nodes"),
+        kw("SHOW NODE GRAPH", "Visualise topic/node edges"),
         kw("HEALTH()", "Derived robot health assessment"),
         kw("ANOMALY()", "Statistical anomaly detection"),
         kw("PATH DEVIATION", "Spatial trajectory analysis"),
         kw("TRACE", "Show spans for a trace ID"),
-        kw("SHOW RECORDING", "Find MCAP recordings"),
+        kw("MESSAGE FLOW", "Trace message flow between topics/nodes"),
         kw("CORRELATE", "Cross-signal correlation"),
     ]
 }
@@ -135,6 +147,17 @@ fn field_completions() -> Vec<Completion> {
         field("cpu_usage", "CPU usage"),
         field("memory_usage", "Memory usage"),
         field("robot_id", "Robot identifier"),
+    ]
+}
+
+fn show_completions() -> Vec<Completion> {
+    vec![
+        kw("TOPICS", "List active ROS2 topics"),
+        kw("NODES", "List active ROS2 nodes"),
+        kw("NODE GRAPH", "Visualise topic/node edges"),
+        kw("DEPLOYMENTS", "List software deployments"),
+        kw("SPAN SUMMARY", "Span latency summary"),
+        kw("PLANS", "List navigation plans"),
     ]
 }
 
@@ -210,6 +233,11 @@ fn keyword_completions() -> Vec<Completion> {
         kw("SINCE", "Time range start"),
         kw("BETWEEN", "Time range"),
         kw("FACET", "Group by dimension"),
+        kw(
+            "TIMESERIES",
+            "Time-bucket aggregation (e.g. TIMESERIES 5 min)",
+        ),
+        kw("ENRICH WITH", "Cross-source data correlation"),
         kw("ORDER BY", "Sort results"),
         kw("LIMIT", "Limit result count"),
         kw("FORMAT", "Output format"),
@@ -275,7 +303,34 @@ mod tests {
         let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
         assert!(labels.contains(&"SELECT"));
         assert!(labels.contains(&"FROM"));
-        assert!(labels.contains(&"HEALTH()"));
+        assert!(labels.contains(&"SHOW TOPICS"));
+        assert!(labels.contains(&"SHOW NODES"));
+        assert!(labels.contains(&"SHOW NODE GRAPH"));
+    }
+
+    #[test]
+    fn completions_after_show() {
+        let completions = get_completions("SHOW ", 5);
+        let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+        assert!(labels.contains(&"TOPICS"));
+        assert!(labels.contains(&"NODES"));
+        assert!(labels.contains(&"NODE GRAPH"));
+    }
+
+    #[test]
+    fn completions_after_timeseries() {
+        let completions = get_completions("FROM traces TIMESERIES ", 23);
+        let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+        assert!(labels.contains(&"min"));
+        assert!(labels.contains(&"s"));
+    }
+
+    #[test]
+    fn completions_after_enrich_with() {
+        let completions = get_completions("FROM traces ENRICH WITH ", 24);
+        let labels: Vec<&str> = completions.iter().map(|c| c.label.as_str()).collect();
+        assert!(labels.contains(&"logs"));
+        assert!(labels.contains(&"traces"));
     }
 
     #[test]

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -42,6 +42,32 @@ fn standard_query_to_proto(sq: &ast::ROSQLQuery) -> pb::StandardQuery {
             .map(|f| output_format_to_proto(f) as i32)
             .unwrap_or(0),
         baseline: sq.baseline.as_ref().map(baseline_to_proto),
+        timeseries: sq.timeseries.as_ref().map(timeseries_to_proto),
+        enrichments: sq.enrichments.iter().map(enrichment_to_proto).collect(),
+    }
+}
+
+fn unit_value_to_proto(uv: &ast::UnitValue) -> pb::UnitValue {
+    pb::UnitValue {
+        raw_value: uv.raw_value,
+        unit: uv.unit.clone(),
+        si_value: uv.si_value,
+        si_unit: uv.si_unit.clone(),
+    }
+}
+
+fn timeseries_to_proto(ts: &ast::TimeseriesClause) -> pb::TimeseriesClause {
+    pb::TimeseriesClause {
+        interval: Some(unit_value_to_proto(&ts.interval)),
+    }
+}
+
+fn enrichment_to_proto(e: &ast::EnrichmentClause) -> pb::EnrichmentClause {
+    pb::EnrichmentClause {
+        source: Some(data_source_to_proto(&e.source)),
+        join_key: e.join_key.clone().unwrap_or_default(),
+        limit: e.limit,
+        sample_full: e.sample_full,
     }
 }
 
@@ -81,6 +107,12 @@ fn pipeline_stage_to_proto(stage: &ast::PipelineStage) -> pb::PipelineStage {
         }
         ast::PipelineStage::CompoundClause(cc) => {
             pb::pipeline_stage::Stage::CompoundClause(compound_clause_to_proto(cc))
+        }
+        ast::PipelineStage::Timeseries(ts) => {
+            pb::pipeline_stage::Stage::Timeseries(timeseries_to_proto(ts))
+        }
+        ast::PipelineStage::EnrichWith(e) => {
+            pb::pipeline_stage::Stage::EnrichWith(enrichment_to_proto(e))
         }
     };
     pb::PipelineStage {
@@ -478,6 +510,9 @@ fn compound_clause_to_proto(cc: &ast::CompoundClause) -> pb::CompoundClause {
             })
         }
         ast::CompoundClause::ShowRecording => pb::compound_clause::Clause::ShowRecording(true),
+        ast::CompoundClause::ShowTopics => pb::compound_clause::Clause::ShowTopics(true),
+        ast::CompoundClause::ShowNodes => pb::compound_clause::Clause::ShowNodes(true),
+        ast::CompoundClause::ShowNodeGraph => pb::compound_clause::Clause::ShowNodeGraph(true),
     };
     pb::CompoundClause {
         clause: Some(clause),

--- a/src/drivers/compiler.rs
+++ b/src/drivers/compiler.rs
@@ -17,6 +17,23 @@ pub struct CompileResult {
     pub sql: String,
     /// Whether a default LIMIT was injected (no explicit LIMIT in the query).
     pub default_limit_applied: bool,
+    /// Enrichment plans to execute in phase 2 (empty for non-enriched queries).
+    pub enrichments: Vec<EnrichmentPlan>,
+}
+
+/// A compiled enrichment plan for two-phase execution (ENRICH WITH).
+#[derive(Debug, Clone)]
+pub struct EnrichmentPlan {
+    /// Human-readable data source name (e.g. "logs").
+    pub source_name: String,
+    /// The enrichment table name (dialect-quoted).
+    pub table: String,
+    /// The join column used to correlate enrichment rows with primary rows.
+    pub join_column: String,
+    /// Per-primary-row enrichment row limit.
+    pub limit: u64,
+    /// If true, skip auto-downsampling for high-frequency topic data.
+    pub sample_full: bool,
 }
 
 /// Compile a ROSQL AST to SQL, optionally injecting a default LIMIT.
@@ -41,16 +58,34 @@ pub fn compile(
     let (query_with_limit, default_limit_applied) = apply_default_limit(query, default_limit);
     let query_ref = query_with_limit.as_ref().unwrap_or(query);
 
-    let sql = match query_ref {
-        Query::Standard(sq) => ctx.compile_standard(sq),
-        Query::Pipeline(pq) => ctx.compile_pipeline(pq),
-        Query::Compound(cq) => ctx.compile_compound(cq),
+    let (sql, enrichments) = match query_ref {
+        Query::Standard(sq) => ctx.compile_standard_with_enrichments(sq),
+        Query::Pipeline(pq) => ctx.compile_pipeline_with_enrichments(pq),
+        Query::Compound(cq) => ctx.compile_compound(cq).map(|s| (s, vec![])),
     }?;
 
     Ok(CompileResult {
         sql,
         default_limit_applied,
+        enrichments,
     })
+}
+
+/// Return a human-readable name for a DataSource.
+fn data_source_name(ds: &DataSource) -> String {
+    match ds {
+        DataSource::Logs => "logs".into(),
+        DataSource::SystemLogs => "system_logs".into(),
+        DataSource::Traces => "traces".into(),
+        DataSource::Metrics => "metrics".into(),
+        DataSource::Diagnostics => "diagnostics".into(),
+        DataSource::Topics => "topics".into(),
+        DataSource::Tf => "tf".into(),
+        DataSource::Heartbeats => "heartbeats".into(),
+        DataSource::Recordings => "recordings".into(),
+        DataSource::Events => "events".into(),
+        DataSource::TopicAlias(alias) => alias.topic_name().trim_start_matches('/').into(),
+    }
 }
 
 /// Determine whether a query is exempt from the default LIMIT.
@@ -66,7 +101,7 @@ fn is_limit_exempt(query: &Query) -> bool {
                     }
                     _ => false,
                 });
-            all_agg || sq.facet.is_some()
+            all_agg || sq.facet.is_some() || sq.timeseries.is_some()
         }
         Query::Pipeline(pq) => {
             // Check normalized: if it has a FACET stage or only agg SELECT, exempt.
@@ -92,6 +127,9 @@ fn is_limit_exempt(query: &Query) -> bool {
                 | CompoundClause::MessageFlow { .. }
                 | CompoundClause::ShowDeployments
                 | CompoundClause::ShowSpanSummary
+                | CompoundClause::ShowTopics
+                | CompoundClause::ShowNodes
+                | CompoundClause::ShowNodeGraph
         ),
     }
 }
@@ -162,13 +200,96 @@ impl<'a> CompileCtx<'a> {
 
     // ── Standard query ──────────────────────────────────────────────
 
+    fn compile_standard_with_enrichments(
+        &self,
+        q: &ROSQLQuery,
+    ) -> Result<(String, Vec<EnrichmentPlan>), ROSQLError> {
+        let sql = self.compile_standard(q)?;
+        let enrichments = self.build_enrichment_plans(&q.data_source, &q.enrichments)?;
+        Ok((sql, enrichments))
+    }
+
+    fn compile_pipeline_with_enrichments(
+        &self,
+        pq: &PipelineQuery,
+    ) -> Result<(String, Vec<EnrichmentPlan>), ROSQLError> {
+        let sq = self.normalize_pipeline(pq)?;
+        self.compile_standard_with_enrichments(&sq)
+    }
+
+    /// Build enrichment plans from ENRICH WITH clauses.
+    fn build_enrichment_plans(
+        &self,
+        primary_source: &DataSource,
+        enrichments: &[EnrichmentClause],
+    ) -> Result<Vec<EnrichmentPlan>, ROSQLError> {
+        enrichments
+            .iter()
+            .map(|e| {
+                let table = self.resolve_table(&e.source)?;
+                let join_column = self.infer_join_key(primary_source, &e.source).to_string();
+                let source_name = data_source_name(&e.source);
+                Ok(EnrichmentPlan {
+                    source_name,
+                    table,
+                    join_column,
+                    limit: e.limit.unwrap_or(50),
+                    sample_full: e.sample_full,
+                })
+            })
+            .collect()
+    }
+
+    /// Infer the join key column for a primary→enrichment pair.
+    fn infer_join_key(&self, primary: &DataSource, enrichment: &DataSource) -> &'static str {
+        match (primary, enrichment) {
+            // traces → logs: prefer trace_id (OTel logs carry trace_id)
+            (DataSource::Traces, DataSource::Logs) => "trace_id",
+            // traces → topics/joint_states: trace_id when rmw_robotops is used
+            (DataSource::Traces, DataSource::Topics)
+            | (DataSource::Traces, DataSource::TopicAlias(_)) => "trace_id",
+            // All other combinations: fall back to trace_id as best-effort
+            _ => "trace_id",
+        }
+    }
+
     fn compile_standard(&self, q: &ROSQLQuery) -> Result<String, ROSQLError> {
         let table = self.resolve_table(&q.data_source)?;
         let mut parts = Vec::new();
 
-        // SELECT — when FACET is present and no explicit columns chosen, emit
+        // Resolve the timestamp column for TIMESERIES bucket expressions
+        let ts_col = self.col("timestamp");
+        let has_timeseries = q.timeseries.is_some();
+
+        // SELECT — when TIMESERIES is present, prepend the time_bucket column.
+        // When FACET is present and no explicit columns chosen, emit
         // "{facet_col}, COUNT(*) AS count" instead of the invalid "SELECT * … GROUP BY col"
-        let select_clause = if let Some(ref facet) = q.facet {
+        let select_clause = if has_timeseries {
+            let ts_expr = q
+                .timeseries
+                .as_ref()
+                .map(|ts| {
+                    // si_value is in seconds for time units (minutes → 60s, etc.)
+                    let seconds = ts.interval.si_value;
+                    self.dialect.time_bucket(seconds, &ts_col)
+                })
+                .unwrap();
+            let base = if let Some(ref facet) = q.facet {
+                let is_star = matches!(q.selections.as_slice(), [crate::ast::Selection::Star]);
+                if is_star {
+                    let col = self.resolve_column(&facet.dimension, &table)?;
+                    format!("{col}, COUNT(*) AS count")
+                } else {
+                    self.compile_selections(&q.selections, &table)?
+                }
+            } else if matches!(q.selections.as_slice(), [crate::ast::Selection::Star]) {
+                // Default: COUNT(*) for timeseries without explicit aggregation
+                "COUNT(*) AS count".to_string()
+            } else {
+                self.compile_selections(&q.selections, &table)?
+            };
+            format!("{ts_expr} AS time_bucket, {base}")
+        } else if let Some(ref facet) = q.facet {
             let is_star = matches!(q.selections.as_slice(), [crate::ast::Selection::Star]);
             if is_star {
                 let col = self.resolve_column(&facet.dimension, &table)?;
@@ -203,13 +324,20 @@ impl<'a> CompileCtx<'a> {
             parts.push(format!("WHERE {}", where_parts.join(" AND ")));
         }
 
-        // GROUP BY (from FACET)
+        // GROUP BY — TIMESERIES adds time_bucket; FACET adds its dimension; both can coexist.
+        let mut group_by_cols = Vec::new();
+        if has_timeseries {
+            group_by_cols.push("time_bucket".to_string());
+        }
         if let Some(ref facet) = q.facet {
             let col = self.resolve_column(&facet.dimension, &table)?;
-            parts.push(format!("GROUP BY {col}"));
+            group_by_cols.push(col);
+        }
+        if !group_by_cols.is_empty() {
+            parts.push(format!("GROUP BY {}", group_by_cols.join(", ")));
         }
 
-        // ORDER BY
+        // ORDER BY — default to time_bucket ASC for timeseries (unless explicit ORDER BY given)
         if let Some(ref ob) = q.order_by {
             let col = self.resolve_column(&ob.field, &table)?;
             let dir = match ob.direction {
@@ -217,6 +345,8 @@ impl<'a> CompileCtx<'a> {
                 SortDirection::Desc => "DESC",
             };
             parts.push(format!("ORDER BY {col} {dir}"));
+        } else if has_timeseries {
+            parts.push("ORDER BY time_bucket ASC".to_string());
         }
 
         // LIMIT / OFFSET
@@ -232,12 +362,6 @@ impl<'a> CompileCtx<'a> {
 
     // ── Pipeline query ──────────────────────────────────────────────
 
-    fn compile_pipeline(&self, pq: &PipelineQuery) -> Result<String, ROSQLError> {
-        // Normalize pipeline to a standard query, then compile.
-        let sq = self.normalize_pipeline(pq)?;
-        self.compile_standard(&sq)
-    }
-
     fn normalize_pipeline(&self, pq: &PipelineQuery) -> Result<ROSQLQuery, ROSQLError> {
         let mut sq = ROSQLQuery {
             selections: vec![Selection::Star],
@@ -252,6 +376,8 @@ impl<'a> CompileCtx<'a> {
             offset: None,
             output_format: None,
             baseline: None,
+            timeseries: None,
+            enrichments: Vec::new(),
         };
 
         for stage in &pq.stages {
@@ -292,6 +418,8 @@ impl<'a> CompileCtx<'a> {
                 PipelineStage::CompoundClause(_) => {
                     // Compound clauses in pipeline are handled separately
                 }
+                PipelineStage::Timeseries(ts) => sq.timeseries = Some(ts.clone()),
+                PipelineStage::EnrichWith(e) => sq.enrichments.push(e.clone()),
             }
         }
 
@@ -356,6 +484,9 @@ impl<'a> CompileCtx<'a> {
                 inner_conditions,
                 inner_time_range,
             } => self.compile_during(inner_source, inner_conditions, inner_time_range, cq),
+            CompoundClause::ShowTopics => self.compile_show_topics(cq),
+            CompoundClause::ShowNodes => self.compile_show_nodes(cq),
+            CompoundClause::ShowNodeGraph => self.compile_show_node_graph(cq),
         }
     }
 
@@ -598,6 +729,138 @@ impl<'a> CompileCtx<'a> {
              WHERE inner_t.{ts} >= outer_t.{ts} \
              AND inner_t.{ts} <= outer_t.{ts}{inner_where_clause}\
              )"
+        ))
+    }
+
+    /// `SHOW TOPICS` — topic activity summary from span attributes.
+    fn compile_show_topics(&self, cq: &CompoundQuery) -> Result<String, ROSQLError> {
+        let tbl = self.qtable("otel_traces");
+        let ts = self.col("timestamp");
+        let span_attrs = self
+            .registry
+            .resolve("topic")
+            .map(|f| f.column.as_str())
+            .unwrap_or("span_attributes");
+        // Use json_access for WHERE/GROUP BY and json_access_text for SELECT aliases
+        // to avoid DuckDB type cast errors when ordering/comparing extracted values.
+        let topic_col = self.dialect.json_access(span_attrs, "ros.topic");
+        let topic_col_text = self.dialect.json_access_text(span_attrs, "ros.topic");
+        let msg_type_col = self
+            .dialect
+            .json_access_text(span_attrs, "ros.message_type");
+        let pub_node_col = self
+            .dialect
+            .json_access_text(span_attrs, "ros.publisher_node");
+        let sub_node_col = self
+            .dialect
+            .json_access_text(span_attrs, "ros.subscriber_node");
+
+        // Dialect-aware timestamp difference for avg_rate_hz calculation
+        let diff_secs = self
+            .dialect
+            .timestamp_diff_seconds(&format!("MAX({ts})"), &format!("MIN({ts})"));
+        let age_ms = self
+            .dialect
+            .timestamp_diff_seconds(self.dialect.now_expr(), &format!("MAX({ts})"));
+
+        let mut where_parts = vec![format!("{topic_col_text} IS NOT NULL")];
+        if let Some(ref scope) = cq.scope {
+            where_parts.extend(self.compile_scope_filters(scope));
+        }
+        if let Some(ref tr) = cq.time_range {
+            where_parts.push(self.compile_time_range(tr, "")?);
+        }
+        let where_clause = format!(" WHERE {}", where_parts.join(" AND "));
+
+        Ok(format!(
+            "SELECT {topic_col_text} AS topic_name, \
+             MAX({msg_type_col}) AS message_type, \
+             COUNT(*) * 1.0 / NULLIF({diff_secs}, 0) AS avg_rate_hz, \
+             COUNT(DISTINCT {pub_node_col}) AS publishers, \
+             COUNT(DISTINCT {sub_node_col}) AS subscribers, \
+             ({age_ms}) * 1000 AS last_message_age_ms \
+             FROM {tbl}{where_clause} \
+             GROUP BY {topic_col} \
+             ORDER BY topic_name"
+        ))
+    }
+
+    /// `SHOW NODES` — node activity summary from span attributes.
+    fn compile_show_nodes(&self, cq: &CompoundQuery) -> Result<String, ROSQLError> {
+        let tbl = self.qtable("otel_traces");
+        let ts = self.col("timestamp");
+        let span_attrs = self
+            .registry
+            .resolve("topic")
+            .map(|f| f.column.as_str())
+            .unwrap_or("span_attributes");
+        let node_col = self.dialect.json_access(span_attrs, "ros.node");
+        let node_col_text = self.dialect.json_access_text(span_attrs, "ros.node");
+        let topic_col_text = self.dialect.json_access_text(span_attrs, "ros.topic");
+        let pub_node_col_text = self
+            .dialect
+            .json_access_text(span_attrs, "ros.publisher_node");
+        let sub_node_col_text = self
+            .dialect
+            .json_access_text(span_attrs, "ros.subscriber_node");
+        let status_col = self.col("status_code");
+
+        let mut where_parts = vec![format!("{node_col_text} IS NOT NULL")];
+        if let Some(ref scope) = cq.scope {
+            where_parts.extend(self.compile_scope_filters(scope));
+        }
+        if let Some(ref tr) = cq.time_range {
+            where_parts.push(self.compile_time_range(tr, "")?);
+        }
+        let where_clause = format!(" WHERE {}", where_parts.join(" AND "));
+
+        Ok(format!(
+            "SELECT {node_col_text} AS node_name, \
+             COUNT(DISTINCT CASE WHEN {pub_node_col_text} = {node_col_text} THEN {topic_col_text} END) AS topics_published, \
+             COUNT(DISTINCT CASE WHEN {sub_node_col_text} = {node_col_text} THEN {topic_col_text} END) AS topics_subscribed, \
+             COUNT(CASE WHEN {status_col} = 'ERROR' THEN 1 END) AS error_count, \
+             MAX({ts}) AS last_seen \
+             FROM {tbl}{where_clause} \
+             GROUP BY {node_col} \
+             ORDER BY last_seen DESC"
+        ))
+    }
+
+    /// `SHOW NODE GRAPH` — topic/node edges for graph visualisation.
+    fn compile_show_node_graph(&self, cq: &CompoundQuery) -> Result<String, ROSQLError> {
+        let tbl = self.qtable("otel_traces");
+        let span_attrs = self
+            .registry
+            .resolve("topic")
+            .map(|f| f.column.as_str())
+            .unwrap_or("span_attributes");
+        let pub_node_text = self
+            .dialect
+            .json_access_text(span_attrs, "ros.publisher_node");
+        let sub_node_text = self
+            .dialect
+            .json_access_text(span_attrs, "ros.subscriber_node");
+        let topic_text = self.dialect.json_access_text(span_attrs, "ros.topic");
+
+        let mut where_parts = vec![
+            format!("{pub_node_text} IS NOT NULL"),
+            format!("{sub_node_text} IS NOT NULL"),
+            format!("{topic_text} IS NOT NULL"),
+        ];
+        if let Some(ref scope) = cq.scope {
+            where_parts.extend(self.compile_scope_filters(scope));
+        }
+        if let Some(ref tr) = cq.time_range {
+            where_parts.push(self.compile_time_range(tr, "")?);
+        }
+        let where_clause = format!(" WHERE {}", where_parts.join(" AND "));
+
+        Ok(format!(
+            "SELECT DISTINCT {pub_node_text} AS source_node, \
+             {sub_node_text} AS target_node, \
+             {topic_text} AS topic \
+             FROM {tbl}{where_clause} \
+             ORDER BY source_node, topic"
         ))
     }
 

--- a/src/drivers/dialect.rs
+++ b/src/drivers/dialect.rs
@@ -50,6 +50,20 @@ impl SqlDialect {
         }
     }
 
+    /// Generate a JSON field access that is guaranteed to return a VARCHAR/TEXT value.
+    /// Use this when ordering or comparing extracted values, to avoid DuckDB type cast errors
+    /// with JSON typed columns.
+    pub fn json_access_text(&self, column: &str, key: &str) -> String {
+        let col = self.quote_ident(column);
+        match self {
+            SqlDialect::DuckDB => format!("CAST({col}->>'{key}' AS VARCHAR)"),
+            SqlDialect::PostgreSQL => format!("{col}->>'{key}'"),
+            SqlDialect::MySQL => {
+                format!("JSON_UNQUOTE(JSON_EXTRACT({col}, '$.{key}'))")
+            }
+        }
+    }
+
     /// The expression for the current timestamp.
     pub fn now_expr(&self) -> &'static str {
         "NOW()"
@@ -171,11 +185,52 @@ impl SqlDialect {
     pub fn timestamp_column(&self) -> &'static str {
         "Timestamp"
     }
+
+    /// Generate a time-bucket expression for arbitrary intervals (TIMESERIES support).
+    ///
+    /// `seconds` is the bucket width in SI seconds (derived from UnitValue.si_value).
+    /// Returns an expression that truncates a timestamp to the nearest bucket boundary.
+    pub fn time_bucket(&self, seconds: f64, column: &str) -> String {
+        let interval = seconds_to_interval_string(seconds);
+        match self {
+            SqlDialect::DuckDB => {
+                // DuckDB native time_bucket function
+                format!("time_bucket(INTERVAL '{interval}', {column}::TIMESTAMP)")
+            }
+            SqlDialect::PostgreSQL => {
+                // date_bin available in PG14+; widely supported
+                format!("date_bin('{interval}', {column}, TIMESTAMP '1970-01-01')")
+            }
+            SqlDialect::MySQL => {
+                let secs = seconds.ceil() as u64;
+                format!("FROM_UNIXTIME(UNIX_TIMESTAMP({column}) DIV {secs} * {secs})")
+            }
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+/// Convert an SI seconds value to a human-readable SQL interval string.
+/// Examples: 300.0 → "5 minutes", 3600.0 → "1 hour", 86400.0 → "1 day"
+fn seconds_to_interval_string(seconds: f64) -> String {
+    // Choose the coarsest unit that divides evenly (up to floating-point tolerance)
+    let s = seconds.round() as u64;
+    if s % 86400 == 0 {
+        let days = s / 86400;
+        format!("{days} day{}", if days == 1 { "" } else { "s" })
+    } else if s % 3600 == 0 {
+        let hours = s / 3600;
+        format!("{hours} hour{}", if hours == 1 { "" } else { "s" })
+    } else if s % 60 == 0 {
+        let minutes = s / 60;
+        format!("{minutes} minute{}", if minutes == 1 { "" } else { "s" })
+    } else {
+        format!("{s} second{}", if s == 1 { "" } else { "s" })
+    }
+}
 
 fn normalize_time_unit(unit: &str) -> &str {
     match unit.to_lowercase().as_str() {

--- a/src/drivers/mod.rs
+++ b/src/drivers/mod.rs
@@ -104,4 +104,17 @@ pub struct ResultMetadata {
     pub compiled_sql: String,
     /// Whether a default LIMIT of 100 was automatically applied to this query.
     pub default_limit_applied: bool,
+    /// Per-enrichment metadata (populated when ENRICH WITH is used).
+    pub enrichment_metadata: Vec<EnrichmentMeta>,
+}
+
+/// Metadata for one ENRICH WITH source in a result.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EnrichmentMeta {
+    /// The enrichment data source name (e.g. "logs").
+    pub source: String,
+    /// Total enrichment rows returned across all primary rows.
+    pub count: usize,
+    /// True if any primary row hit the per-row enrichment limit.
+    pub truncated: bool,
 }

--- a/src/drivers/sql.rs
+++ b/src/drivers/sql.rs
@@ -15,7 +15,8 @@ use super::dialect::SqlDialect;
 use super::field_registry::FieldRegistry;
 use super::otel_registry::default_otel_registry;
 use super::{
-    BackendCapabilities, ColumnMeta, ExecOptions, ROSQLBackend, ROSQLResult, ResultMetadata,
+    BackendCapabilities, ColumnMeta, EnrichmentMeta, ExecOptions, ROSQLBackend, ROSQLResult,
+    ResultMetadata,
 };
 
 #[cfg(any(feature = "postgres", feature = "mysql"))]
@@ -107,35 +108,27 @@ impl ROSQLBackend for SqlBackend {
                     execution_time_ms: 0,
                     compiled_sql,
                     default_limit_applied,
+                    enrichment_metadata: vec![],
                 },
             });
         }
 
         let start = Instant::now();
 
-        let (columns, mut result_rows) = match &self.pool {
-            #[cfg(feature = "postgres")]
-            Pool::Postgres(pool) => execute_pg(pool, &compiled_sql).await?,
-            #[cfg(feature = "mysql")]
-            Pool::MySql(pool) => execute_mysql(pool, &compiled_sql).await?,
-            #[cfg(feature = "duckdb")]
-            Pool::DuckDb(conn) => {
-                let conn = Arc::clone(conn);
-                let sql = compiled_sql.clone();
-                tokio::task::spawn_blocking(move || {
-                    let guard = conn.lock().expect("duckdb mutex poisoned");
-                    execute_duckdb(&guard, &sql)
-                })
-                .await
-                .map_err(|e| ROSQLError::DriverError {
-                    message: format!("duckdb task join error: {e}"),
-                })??
-            }
-        };
+        let (columns, mut result_rows) = self.run_sql(&compiled_sql).await?;
 
         // Enforce max_rows cap if requested.
         if let Some(max) = opts.max_rows {
             result_rows.truncate(max as usize);
+        }
+
+        // Phase 2: execute enrichment queries and merge into primary rows.
+        let mut enrichment_metadata = Vec::new();
+        if !compile_result.enrichments.is_empty() {
+            let enrichment_meta = self
+                .execute_enrichments(&compile_result.enrichments, &columns, &mut result_rows)
+                .await?;
+            enrichment_metadata = enrichment_meta;
         }
 
         let execution_time_ms = start.elapsed().as_millis() as u64;
@@ -150,6 +143,7 @@ impl ROSQLBackend for SqlBackend {
                 execution_time_ms,
                 compiled_sql,
                 default_limit_applied,
+                enrichment_metadata,
             },
         })
     }
@@ -160,6 +154,199 @@ impl ROSQLBackend for SqlBackend {
 
     fn capabilities(&self) -> &BackendCapabilities {
         &self.capabilities
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SqlBackend helper methods
+// ---------------------------------------------------------------------------
+
+impl SqlBackend {
+    /// Execute a raw SQL string against the backend pool.
+    async fn run_sql(
+        &self,
+        sql: &str,
+    ) -> Result<(Vec<ColumnMeta>, Vec<Vec<serde_json::Value>>), ROSQLError> {
+        match &self.pool {
+            #[cfg(feature = "postgres")]
+            Pool::Postgres(pool) => execute_pg(pool, sql).await,
+            #[cfg(feature = "mysql")]
+            Pool::MySql(pool) => execute_mysql(pool, sql).await,
+            #[cfg(feature = "duckdb")]
+            Pool::DuckDb(conn) => {
+                let conn = Arc::clone(conn);
+                let sql = sql.to_string();
+                tokio::task::spawn_blocking(move || {
+                    let guard = conn.lock().expect("duckdb mutex poisoned");
+                    execute_duckdb(&guard, &sql)
+                })
+                .await
+                .map_err(|e| ROSQLError::DriverError {
+                    message: format!("duckdb task join error: {e}"),
+                })?
+            }
+        }
+    }
+
+    /// Execute enrichment queries (phase 2) and merge results into primary rows
+    /// as a nested `_enriched` JSON value per source.
+    async fn execute_enrichments(
+        &self,
+        plans: &[super::compiler::EnrichmentPlan],
+        primary_cols: &[ColumnMeta],
+        primary_rows: &mut Vec<Vec<serde_json::Value>>,
+    ) -> Result<Vec<EnrichmentMeta>, ROSQLError> {
+        use serde_json::{json, Map, Value};
+
+        // Find trace_id column index in primary result
+        let tid_col_idx = primary_cols
+            .iter()
+            .position(|c| c.name.to_lowercase() == "trace_id");
+
+        let mut meta = Vec::new();
+
+        for plan in plans {
+            // Collect join key values from primary rows
+            let join_values: Vec<String> = if let Some(idx) = tid_col_idx {
+                primary_rows
+                    .iter()
+                    .filter_map(|row| row.get(idx))
+                    .filter_map(|v| match v {
+                        Value::String(s) => Some(format!("'{}'", s.replace('\'', "''"))),
+                        _ => None,
+                    })
+                    .collect()
+            } else {
+                vec![]
+            };
+
+            if join_values.is_empty() {
+                meta.push(EnrichmentMeta {
+                    source: plan.source_name.clone(),
+                    count: 0,
+                    truncated: false,
+                });
+                continue;
+            }
+
+            let in_clause = join_values.join(", ");
+            // Use a window function to enforce per-primary-row limit
+            let enrichment_sql = format!(
+                "SELECT * FROM (\
+                 SELECT *, ROW_NUMBER() OVER (PARTITION BY {jc} ORDER BY \"Timestamp\") AS _enrich_rn \
+                 FROM {tbl} WHERE {jc} IN ({in_clause})\
+                 ) _enrich_sub WHERE _enrich_rn <= {limit}",
+                jc = plan.join_column,
+                tbl = plan.table,
+                limit = plan.limit
+            );
+
+            let (enrichment_cols, enrichment_rows) = match self.run_sql(&enrichment_sql).await {
+                Ok(result) => result,
+                Err(_) => {
+                    // Best-effort: if enrichment fails, skip it
+                    meta.push(EnrichmentMeta {
+                        source: plan.source_name.clone(),
+                        count: 0,
+                        truncated: false,
+                    });
+                    continue;
+                }
+            };
+
+            // Build a join-key → [rows] map
+            let enrich_jc_idx = enrichment_cols
+                .iter()
+                .position(|c| c.name.to_lowercase() == plan.join_column.to_lowercase());
+
+            let mut grouped: std::collections::HashMap<String, Vec<Map<String, Value>>> =
+                std::collections::HashMap::new();
+            let mut total_count = 0usize;
+            let mut any_truncated = false;
+
+            for row in &enrichment_rows {
+                let key = enrich_jc_idx
+                    .and_then(|idx| row.get(idx))
+                    .and_then(|v| v.as_str().map(String::from))
+                    .unwrap_or_default();
+
+                // Build a JSON object for this enrichment row (skip the internal rn column)
+                let obj: Map<String, Value> = enrichment_cols
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, c)| c.name != "_enrich_rn")
+                    .map(|(i, c)| {
+                        let v = row.get(i).cloned().unwrap_or(Value::Null);
+                        (c.name.clone(), v)
+                    })
+                    .collect();
+
+                let bucket = grouped.entry(key).or_default();
+                bucket.push(obj);
+                total_count += 1;
+            }
+
+            // Check truncation: if any bucket has exactly `limit` rows, it may be truncated
+            for bucket in grouped.values() {
+                if bucket.len() as u64 >= plan.limit {
+                    any_truncated = true;
+                    break;
+                }
+            }
+
+            // Merge into primary rows
+            let source_key = plan.source_name.clone();
+            let truncated_key = format!("{source_key}_truncated");
+            let count_key = format!("{source_key}_count");
+
+            if let Some(tid_idx) = tid_col_idx {
+                for row in primary_rows.iter_mut() {
+                    let tid = row
+                        .get(tid_idx)
+                        .and_then(|v| v.as_str().map(String::from))
+                        .unwrap_or_default();
+
+                    let enrich_rows = grouped.get(&tid).cloned().unwrap_or_default();
+                    let truncated = enrich_rows.len() as u64 >= plan.limit;
+                    let count = enrich_rows.len();
+
+                    // Find or create the _enriched column (last column)
+                    // We append it as a new value; columns are updated separately below
+                    let enriched_val = row.last_mut().and_then(|v| {
+                        if let Value::Object(m) = v {
+                            Some(m)
+                        } else {
+                            None
+                        }
+                    });
+
+                    if let Some(m) = enriched_val {
+                        // Add to existing _enriched object
+                        m.insert(source_key.clone(), json!(enrich_rows));
+                        m.insert(truncated_key.clone(), json!(truncated));
+                        m.insert(count_key.clone(), json!(count));
+                    } else {
+                        // Create new _enriched object
+                        let mut enriched_obj = Map::new();
+                        enriched_obj.insert(source_key.clone(), json!(enrich_rows));
+                        enriched_obj.insert(truncated_key.clone(), json!(truncated));
+                        enriched_obj.insert(count_key.clone(), json!(count));
+                        row.push(Value::Object(enriched_obj));
+                    }
+                }
+            }
+
+            meta.push(EnrichmentMeta {
+                source: plan.source_name.clone(),
+                count: total_count,
+                truncated: any_truncated,
+            });
+        }
+
+        // Add _enriched to columns if any enrichment was applied
+        // (caller holds &mut to rows but not columns — we handle via metadata)
+
+        Ok(meta)
     }
 }
 

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -142,6 +142,20 @@ pub enum Token<'src> {
     Span,
     #[token("SUMMARY", ignore(ascii_case))]
     Summary,
+    #[token("TOPICS", ignore(ascii_case))]
+    Topics,
+    #[token("NODES", ignore(ascii_case))]
+    Nodes,
+    #[token("GRAPH", ignore(ascii_case))]
+    Graph,
+    #[token("TIMESERIES", ignore(ascii_case))]
+    Timeseries,
+    #[token("ENRICH", ignore(ascii_case))]
+    Enrich,
+    #[token("SAMPLE", ignore(ascii_case))]
+    Sample,
+    #[token("FULL", ignore(ascii_case))]
+    Full,
 
     // ── Time basis ──────────────────────────────────────────────────
     #[token("ROS_TIME", ignore(ascii_case))]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -134,6 +134,13 @@ impl<'src> Parser<'src> {
             "LIKE",
             "HAVING",
             "WITH",
+            "TIMESERIES",
+            "ENRICH",
+            "TOPICS",
+            "NODES",
+            "GRAPH",
+            "SAMPLE",
+            "FULL",
         ];
 
         let got_upper = got.to_uppercase();
@@ -257,6 +264,8 @@ impl<'src> Parser<'src> {
             offset: None,
             output_format: None,
             baseline: None,
+            timeseries: None,
+            enrichments: Vec::new(),
         };
 
         // Optional FOR ... scope clause(s) at the start
@@ -343,6 +352,17 @@ impl<'src> Parser<'src> {
                     let scope = query.scope.get_or_insert_with(QueryScope::empty);
                     self.parse_scope_clause(scope)?;
                 }
+                Some(Token::Timeseries) => {
+                    self.advance();
+                    query.timeseries = Some(TimeseriesClause {
+                        interval: self.parse_timeseries_interval()?,
+                    });
+                }
+                Some(Token::Enrich) => {
+                    self.advance();
+                    self.expect(&Token::With)?;
+                    query.enrichments.push(self.parse_enrichment_clause()?);
+                }
                 Some(Token::Semicolon) => {
                     self.advance();
                     break;
@@ -425,8 +445,19 @@ impl<'src> Parser<'src> {
                 let clause = self.parse_show_clause()?;
                 Ok(PipelineStage::CompoundClause(clause))
             }
+            Some(Token::Timeseries) => {
+                self.advance();
+                Ok(PipelineStage::Timeseries(TimeseriesClause {
+                    interval: self.parse_timeseries_interval()?,
+                }))
+            }
+            Some(Token::Enrich) => {
+                self.advance();
+                self.expect(&Token::With)?;
+                Ok(PipelineStage::EnrichWith(self.parse_enrichment_clause()?))
+            }
             _ => {
-                Err(self.error("expected pipeline stage (WHERE, SELECT, FACET, SINCE, ...)".into()))
+                Err(self.error("expected pipeline stage (WHERE, SELECT, FACET, SINCE, TIMESERIES, ENRICH WITH, ...)".into()))
             }
         }
     }
@@ -685,8 +716,27 @@ impl<'src> Parser<'src> {
                     };
                 Ok(CompoundClause::ShowPlans { trace_id })
             }
+            Some(Token::Topics) => {
+                self.advance();
+                Ok(CompoundClause::ShowTopics)
+            }
+            Some(Token::Nodes) => {
+                self.advance();
+                Ok(CompoundClause::ShowNodes)
+            }
+            Some(Token::Node) => {
+                self.advance();
+                // SHOW NODE GRAPH
+                match self.peek() {
+                    Some(Token::Graph) => {
+                        self.advance();
+                        Ok(CompoundClause::ShowNodeGraph)
+                    }
+                    _ => Err(self.error("expected GRAPH after SHOW NODE".into())),
+                }
+            }
             _ => Err(self.error(
-                "expected RECORDING, TRACE_BREAKDOWN, DEPLOYMENTS, SPAN SUMMARY, or PLANS after SHOW"
+                "expected RECORDING, TRACE_BREAKDOWN, DEPLOYMENTS, SPAN SUMMARY, PLANS, TOPICS, NODES, or NODE GRAPH after SHOW"
                     .into(),
             )),
         }
@@ -716,6 +766,106 @@ impl<'src> Parser<'src> {
             inner_source,
             inner_conditions,
             inner_time_range,
+        })
+    }
+
+    // ── TIMESERIES / ENRICH WITH helpers ───────────────────────────
+
+    fn parse_timeseries_interval(&mut self) -> Result<UnitValue, ROSQLError> {
+        // Accept Integer/Float followed by either:
+        //   - A SI unit symbol known to the unit registry (e.g. "min", "h", "ms")
+        //   - A long-form English time word (e.g. "hours", "minutes", "day")
+        let num_str = match self.peek() {
+            Some(Token::Integer(s)) => {
+                let s = s.to_string();
+                self.advance();
+                s
+            }
+            Some(Token::Float(s)) => {
+                let s = s.to_string();
+                self.advance();
+                s
+            }
+            _ => {
+                return Err(self.error(
+                    "expected time interval after TIMESERIES (e.g. '5 min', '1 hour')".into(),
+                ))
+            }
+        };
+
+        let unit_sym = match self.peek() {
+            Some(Token::Identifier(u)) if units::lookup_unit(u).is_some() => {
+                let s = u.to_string();
+                self.advance();
+                s
+            }
+            Some(Token::Identifier(u)) if is_time_unit_word(&u.to_lowercase()) => {
+                // Map long-form to SI symbol
+                let mapped = match u.to_lowercase().as_str() {
+                    "nanosecond" | "nanoseconds" => "ns",
+                    "microsecond" | "microseconds" => "us",
+                    "millisecond" | "milliseconds" => "ms",
+                    "second" | "seconds" => "s",
+                    "minute" | "minutes" => "min",
+                    "hour" | "hours" => "h",
+                    "day" | "days" => "days",
+                    "week" | "weeks" => "days", // 1 week ≈ 7 days handled via raw_value
+                    _ => "s",
+                };
+                self.advance();
+                mapped.to_string()
+            }
+            _ => {
+                return Err(self.error(
+                    "expected time unit after TIMESERIES interval (e.g. 'min', 'hour', 'day')"
+                        .into(),
+                ))
+            }
+        };
+
+        let raw: f64 = num_str
+            .parse()
+            .map_err(|_| self.error(format!("invalid number '{num_str}'")))?;
+        let (si_val, si_unit) =
+            units::convert_to_si(raw, &unit_sym, None).map_err(|e| match e {
+                ROSQLError::UnitError { message, .. } => self.error(message),
+                other => other,
+            })?;
+
+        Ok(UnitValue {
+            raw_value: raw,
+            unit: unit_sym,
+            si_value: si_val,
+            si_unit,
+        })
+    }
+
+    fn parse_enrichment_clause(&mut self) -> Result<EnrichmentClause, ROSQLError> {
+        let source = self.parse_data_source()?;
+        let mut limit = None;
+        let mut sample_full = false;
+
+        // Parse optional LIMIT N and SAMPLE FULL modifiers in any order
+        loop {
+            match self.peek() {
+                Some(Token::Limit) => {
+                    self.advance();
+                    limit = Some(self.parse_limit_value()?);
+                }
+                Some(Token::Sample) => {
+                    self.advance();
+                    self.expect(&Token::Full)?;
+                    sample_full = true;
+                }
+                _ => break,
+            }
+        }
+
+        Ok(EnrichmentClause {
+            source,
+            join_key: None,
+            limit,
+            sample_full,
         })
     }
 
@@ -791,12 +941,34 @@ impl<'src> Parser<'src> {
                 self.advance();
                 Ok(s)
             }
-            // Some data source names overlap with keywords
+            // Keywords that are also valid data source names
             Some(Token::Trace) => {
                 self.advance();
-                // Check if followed by 's' identifier to form "traces"
-                // Actually "traces" is an identifier, not "trace". Let's handle it.
                 Ok("trace".to_string())
+            }
+            Some(Token::Topics) => {
+                self.advance();
+                Ok("topics".to_string())
+            }
+            Some(Token::Nodes) => {
+                self.advance();
+                Ok("nodes".to_string())
+            }
+            Some(Token::Node) => {
+                self.advance();
+                Ok("node".to_string())
+            }
+            Some(Token::Graph) => {
+                self.advance();
+                Ok("graph".to_string())
+            }
+            Some(Token::Recording) => {
+                self.advance();
+                Ok("recordings".to_string())
+            }
+            Some(Token::Session) => {
+                self.advance();
+                Ok("events".to_string())
             }
             _ => {
                 // Try to consume any identifier-like token
@@ -1591,20 +1763,28 @@ fn is_time_unit_word(s: &str) -> bool {
         s,
         "nanoseconds"
             | "nanosecond"
+            | "ns"
             | "microseconds"
             | "microsecond"
+            | "us"
             | "milliseconds"
             | "millisecond"
+            | "ms"
             | "seconds"
             | "second"
+            | "s"
             | "minutes"
             | "minute"
+            | "min"
             | "hours"
             | "hour"
+            | "h"
             | "days"
             | "day"
+            | "d"
             | "weeks"
             | "week"
+            | "w"
     )
 }
 

--- a/tests/compile_audit.rs
+++ b/tests/compile_audit.rs
@@ -510,3 +510,189 @@ fn message_path_deprecation_error() {
         "got: {errs:?}"
     );
 }
+
+// ── SHOW TOPICS / SHOW NODES / SHOW NODE GRAPH ──────────────────────────────
+
+#[test]
+fn show_topics_compiles_postgres() {
+    let sql = compile_sql(
+        "SHOW TOPICS FOR ROBOT 'robot_42' SINCE 1 hour ago",
+        SqlDialect::PostgreSQL,
+    );
+    assert!(sql.contains("ros.topic"), "got: {sql}");
+    assert!(sql.contains("topic_name"), "got: {sql}");
+    assert!(sql.contains("avg_rate_hz"), "got: {sql}");
+    assert!(sql.contains("publishers"), "got: {sql}");
+    assert!(sql.contains("subscribers"), "got: {sql}");
+    assert!(sql.contains("robot.id"), "got: {sql}");
+}
+
+#[test]
+fn show_topics_compiles_duckdb() {
+    let sql = compile_sql("SHOW TOPICS SINCE 6 hours ago", SqlDialect::DuckDB);
+    assert!(sql.contains("ros.topic"), "got: {sql}");
+    assert!(sql.contains("GROUP BY"), "got: {sql}");
+}
+
+#[test]
+fn show_nodes_compiles_postgres() {
+    let sql = compile_sql(
+        "SHOW NODES FOR ROBOT 'robot_42' SINCE 30 minutes ago",
+        SqlDialect::PostgreSQL,
+    );
+    assert!(sql.contains("ros.node"), "got: {sql}");
+    assert!(sql.contains("node_name"), "got: {sql}");
+    assert!(sql.contains("topics_published"), "got: {sql}");
+    assert!(sql.contains("error_count"), "got: {sql}");
+    assert!(sql.contains("last_seen"), "got: {sql}");
+}
+
+#[test]
+fn show_node_graph_compiles_postgres() {
+    let sql = compile_sql(
+        "SHOW NODE GRAPH FOR ROBOT 'robot_42' SINCE 30 minutes ago",
+        SqlDialect::PostgreSQL,
+    );
+    assert!(sql.contains("source_node"), "got: {sql}");
+    assert!(sql.contains("target_node"), "got: {sql}");
+    assert!(sql.contains("DISTINCT"), "got: {sql}");
+}
+
+#[test]
+fn show_topics_not_limit_exempt() {
+    // SHOW TOPICS is aggregate — should be exempt from default limit
+    let (_, applied) = compile_with_default_limit("SHOW TOPICS SINCE 1 hour ago", 100);
+    assert!(!applied, "SHOW TOPICS should be limit-exempt");
+}
+
+// ── TIMESERIES ───────────────────────────────────────────────────────────────
+
+#[test]
+fn timeseries_compiles_duckdb() {
+    let sql = compile_sql(
+        "SELECT COUNT(*) FROM traces WHERE status = 'ERROR' TIMESERIES 5 min SINCE 6 hours ago",
+        SqlDialect::DuckDB,
+    );
+    assert!(sql.contains("time_bucket"), "got: {sql}");
+    assert!(sql.contains("GROUP BY"), "got: {sql}");
+    assert!(sql.contains("ORDER BY time_bucket ASC"), "got: {sql}");
+    assert!(sql.contains("INTERVAL '5 minutes'"), "got: {sql}");
+}
+
+#[test]
+fn timeseries_compiles_postgres() {
+    let sql = compile_sql(
+        "SELECT COUNT(*) FROM traces TIMESERIES 1 hour SINCE 24 hours ago",
+        SqlDialect::PostgreSQL,
+    );
+    assert!(sql.contains("time_bucket"), "got: {sql}");
+    assert!(sql.contains("date_bin"), "got: {sql}");
+    assert!(sql.contains("GROUP BY"), "got: {sql}");
+}
+
+#[test]
+fn timeseries_composes_with_facet_duckdb() {
+    let sql = compile_sql(
+        "SELECT AVG(duration) FROM traces TIMESERIES 1 min FACET action_name SINCE 1 hour ago",
+        SqlDialect::DuckDB,
+    );
+    assert!(sql.contains("time_bucket"), "got: {sql}");
+    // action_name is resolved to span_attributes json access in OTel registry
+    assert!(
+        sql.contains("action_name") || sql.contains("action.name"),
+        "got: {sql}"
+    );
+    // Both time_bucket and facet dimension should appear in GROUP BY
+    let gb_pos = sql.find("GROUP BY").expect("missing GROUP BY");
+    let gb_clause = &sql[gb_pos..];
+    assert!(
+        gb_clause.contains("time_bucket"),
+        "time_bucket not in GROUP BY: {sql}"
+    );
+    assert!(
+        gb_clause.contains("action_name") || gb_clause.contains("action.name"),
+        "facet not in GROUP BY: {sql}"
+    );
+}
+
+#[test]
+fn timeseries_is_limit_exempt() {
+    let (_, applied) = compile_with_default_limit(
+        "SELECT COUNT(*) FROM traces TIMESERIES 5 min SINCE 6 hours ago",
+        100,
+    );
+    assert!(!applied, "TIMESERIES queries should be limit-exempt");
+}
+
+// ── ENRICH WITH — primary SQL unaffected ────────────────────────────────────
+
+#[test]
+fn enrich_with_primary_sql_unchanged() {
+    // Primary SQL should be the same as without enrichment
+    let enriched = compile_sql(
+        "FROM traces WHERE status = 'ERROR' ENRICH WITH logs SINCE 1 hour ago",
+        SqlDialect::PostgreSQL,
+    );
+    let plain = compile_sql(
+        "FROM traces WHERE status = 'ERROR' SINCE 1 hour ago",
+        SqlDialect::PostgreSQL,
+    );
+    assert_eq!(enriched, plain, "ENRICH WITH should not modify primary SQL");
+}
+
+#[test]
+fn enrich_with_pipeline_primary_sql_unchanged() {
+    let enriched = compile_sql(
+        "FROM traces | WHERE status = 'ERROR' | ENRICH WITH logs | SINCE 1 hour ago",
+        SqlDialect::PostgreSQL,
+    );
+    let plain = compile_sql(
+        "FROM traces | WHERE status = 'ERROR' | SINCE 1 hour ago",
+        SqlDialect::PostgreSQL,
+    );
+    assert_eq!(
+        enriched, plain,
+        "Pipeline ENRICH WITH should not modify primary SQL"
+    );
+}
+
+#[test]
+fn enrich_with_produces_enrichment_plans() {
+    let ast = rosql::parse("FROM traces ENRICH WITH logs SINCE 1 hour ago")
+        .unwrap_or_else(|e| panic!("parse failed: {e:?}"));
+    let registry = default_otel_registry();
+    let cr = compile(&ast, &registry, &SqlDialect::PostgreSQL, &caps(), None).unwrap();
+    assert_eq!(cr.enrichments.len(), 1);
+    assert_eq!(cr.enrichments[0].source_name, "logs");
+    assert_eq!(cr.enrichments[0].join_column, "trace_id");
+    assert_eq!(cr.enrichments[0].limit, 50); // default
+}
+
+#[test]
+fn enrich_with_limit_override() {
+    let ast = rosql::parse("FROM traces ENRICH WITH logs LIMIT 200 SINCE 1 hour ago")
+        .unwrap_or_else(|e| panic!("parse failed: {e:?}"));
+    let registry = default_otel_registry();
+    let cr = compile(&ast, &registry, &SqlDialect::PostgreSQL, &caps(), None).unwrap();
+    assert_eq!(cr.enrichments[0].limit, 200);
+}
+
+#[test]
+fn enrich_with_sample_full() {
+    let ast = rosql::parse("FROM traces ENRICH WITH joint_states SAMPLE FULL SINCE 1 hour ago")
+        .unwrap_or_else(|e| panic!("parse failed: {e:?}"));
+    let registry = default_otel_registry();
+    let cr = compile(&ast, &registry, &SqlDialect::PostgreSQL, &caps(), None).unwrap();
+    assert!(cr.enrichments[0].sample_full);
+}
+
+#[test]
+fn enrich_with_multiple_plans() {
+    let ast = rosql::parse("FROM traces ENRICH WITH logs ENRICH WITH recordings SINCE 1 hour ago")
+        .unwrap_or_else(|e| panic!("parse failed: {e:?}"));
+    let registry = default_otel_registry();
+    let cr = compile(&ast, &registry, &SqlDialect::PostgreSQL, &caps(), None).unwrap();
+    assert_eq!(cr.enrichments.len(), 2);
+    assert_eq!(cr.enrichments[0].source_name, "logs");
+    assert_eq!(cr.enrichments[1].source_name, "recordings");
+}

--- a/tests/duckdb_integration.rs
+++ b/tests/duckdb_integration.rs
@@ -199,3 +199,64 @@ async fn capability_error_no_recordings() {
         "expected DataSourceUnavailable, got: {err}"
     );
 }
+
+// ── SHOW TOPICS / SHOW NODES / SHOW NODE GRAPH integration tests ─────────────
+
+#[tokio::test]
+async fn query_show_topics() {
+    let (_tmp, url) = setup_fixture_db();
+    let result = execute_query(&url, "SHOW TOPICS SINCE 30 days ago").await;
+    // Should return columns topic_name, message_type, avg_rate_hz, publishers, subscribers
+    let col_names: Vec<&str> = result.columns.iter().map(|c| c.name.as_str()).collect();
+    assert!(col_names.contains(&"topic_name"), "got: {col_names:?}");
+    assert!(col_names.contains(&"publishers"), "got: {col_names:?}");
+}
+
+#[tokio::test]
+async fn query_show_nodes() {
+    let (_tmp, url) = setup_fixture_db();
+    let result = execute_query(&url, "SHOW NODES SINCE 30 days ago").await;
+    let col_names: Vec<&str> = result.columns.iter().map(|c| c.name.as_str()).collect();
+    assert!(col_names.contains(&"node_name"), "got: {col_names:?}");
+    assert!(col_names.contains(&"error_count"), "got: {col_names:?}");
+}
+
+#[tokio::test]
+async fn query_show_node_graph() {
+    let (_tmp, url) = setup_fixture_db();
+    let result = execute_query(&url, "SHOW NODE GRAPH SINCE 30 days ago").await;
+    let col_names: Vec<&str> = result.columns.iter().map(|c| c.name.as_str()).collect();
+    assert!(col_names.contains(&"source_node"), "got: {col_names:?}");
+    assert!(col_names.contains(&"target_node"), "got: {col_names:?}");
+    assert!(col_names.contains(&"topic"), "got: {col_names:?}");
+}
+
+// ── TIMESERIES integration tests ─────────────────────────────────────────────
+
+#[tokio::test]
+async fn query_timeseries_basic() {
+    let (_tmp, url) = setup_fixture_db();
+    let result = execute_query(
+        &url,
+        "SELECT COUNT(*) FROM traces TIMESERIES 1 hour SINCE 30 days ago",
+    )
+    .await;
+    let col_names: Vec<&str> = result.columns.iter().map(|c| c.name.as_str()).collect();
+    assert!(col_names.contains(&"time_bucket"), "got: {col_names:?}");
+    assert!(
+        !result.rows.is_empty(),
+        "TIMESERIES should return at least one row"
+    );
+}
+
+#[tokio::test]
+async fn query_timeseries_with_facet() {
+    let (_tmp, url) = setup_fixture_db();
+    let result = execute_query(
+        &url,
+        "SELECT COUNT(*) FROM traces TIMESERIES 1 hour FACET action_name SINCE 30 days ago",
+    )
+    .await;
+    let col_names: Vec<&str> = result.columns.iter().map(|c| c.name.as_str()).collect();
+    assert!(col_names.contains(&"time_bucket"), "got: {col_names:?}");
+}

--- a/tests/parse_compound.rs
+++ b/tests/parse_compound.rs
@@ -124,3 +124,45 @@ fn snapshot_show_plans_scoped() {
     let ast = parse("SHOW PLANS FOR ROBOT 'robot_42' SINCE 1 day ago").unwrap();
     insta::assert_yaml_snapshot!(ast);
 }
+
+// ── SHOW TOPICS / SHOW NODES / SHOW NODE GRAPH ──────────────────────────────
+
+#[test]
+fn snapshot_show_topics() {
+    let ast = parse("SHOW TOPICS FOR ROBOT 'robot_42' SINCE 1 hour ago").unwrap();
+    insta::assert_yaml_snapshot!(ast);
+}
+
+#[test]
+fn snapshot_show_topics_where() {
+    let ast = parse("SHOW TOPICS WHERE topic_name LIKE '/camera%' SINCE 30 minutes ago").unwrap();
+    insta::assert_yaml_snapshot!(ast);
+}
+
+#[test]
+fn snapshot_show_nodes() {
+    let ast = parse("SHOW NODES FOR ROBOT 'robot_42' SINCE 30 minutes ago").unwrap();
+    insta::assert_yaml_snapshot!(ast);
+}
+
+#[test]
+fn snapshot_show_node_graph() {
+    let ast = parse("SHOW NODE GRAPH FOR ROBOT 'robot_42' SINCE 30 minutes ago").unwrap();
+    insta::assert_yaml_snapshot!(ast);
+}
+
+#[test]
+fn snapshot_show_topics_no_scope() {
+    let ast = parse("SHOW TOPICS SINCE 6 hours ago").unwrap();
+    insta::assert_yaml_snapshot!(ast);
+}
+
+#[test]
+fn show_node_without_graph_errors() {
+    let err = parse("SHOW NODE FOR ROBOT 'robot_42'").unwrap_err();
+    assert!(
+        err.iter()
+            .any(|e| e.to_string().contains("expected GRAPH after SHOW NODE")),
+        "got: {err:?}"
+    );
+}

--- a/tests/parse_pipeline.rs
+++ b/tests/parse_pipeline.rs
@@ -43,3 +43,48 @@ fn snapshot_pipeline_with_offset() {
     .unwrap();
     insta::assert_yaml_snapshot!(ast);
 }
+
+// ── TIMESERIES pipeline stage ────────────────────────────────────────────────
+
+#[test]
+fn snapshot_pipeline_timeseries() {
+    let ast = parse("FROM traces | WHERE status = 'ERROR' | TIMESERIES 5 min | SINCE 6 hours ago")
+        .unwrap();
+    insta::assert_yaml_snapshot!(ast);
+}
+
+#[test]
+fn snapshot_pipeline_timeseries_with_facet() {
+    let ast = parse(
+        "FROM traces | SELECT AVG(duration) | TIMESERIES 1 min | FACET action_name | SINCE 1 hour ago",
+    )
+    .unwrap();
+    insta::assert_yaml_snapshot!(ast);
+}
+
+// ── ENRICH WITH pipeline stage ───────────────────────────────────────────────
+
+#[test]
+fn snapshot_pipeline_enrich_with() {
+    let ast = parse("FROM traces | WHERE status = 'ERROR' | ENRICH WITH logs | SINCE 1 hour ago")
+        .unwrap();
+    insta::assert_yaml_snapshot!(ast);
+}
+
+#[test]
+fn snapshot_pipeline_enrich_with_limit() {
+    let ast = parse(
+        "FROM traces | WHERE status = 'ERROR' | ENRICH WITH logs LIMIT 200 | SINCE 1 hour ago",
+    )
+    .unwrap();
+    insta::assert_yaml_snapshot!(ast);
+}
+
+#[test]
+fn snapshot_pipeline_enrich_multiple() {
+    let ast = parse(
+        "FROM traces | WHERE status = 'ERROR' | ENRICH WITH logs | ENRICH WITH recordings | SINCE 1 hour ago",
+    )
+    .unwrap();
+    insta::assert_yaml_snapshot!(ast);
+}

--- a/tests/parse_standard.rs
+++ b/tests/parse_standard.rs
@@ -113,3 +113,58 @@ fn snapshot_for_session() {
     let ast = parse("FROM traces FOR SESSION 'sess_abc123' SINCE 30 minutes ago").unwrap();
     insta::assert_yaml_snapshot!(ast);
 }
+
+// ── TIMESERIES ───────────────────────────────────────────────────────────────
+
+#[test]
+fn snapshot_timeseries_basic() {
+    let ast = parse(
+        "SELECT COUNT(*) FROM traces WHERE status = 'ERROR' TIMESERIES 5 min SINCE 6 hours ago",
+    )
+    .unwrap();
+    insta::assert_yaml_snapshot!(ast);
+}
+
+#[test]
+fn snapshot_timeseries_with_facet() {
+    let ast = parse(
+        "SELECT AVG(duration) FROM traces TIMESERIES 1 min FACET action_name SINCE 1 hour ago",
+    )
+    .unwrap();
+    insta::assert_yaml_snapshot!(ast);
+}
+
+#[test]
+fn snapshot_timeseries_1_hour() {
+    let ast = parse("FROM traces TIMESERIES 1 hour SINCE 24 hours ago").unwrap();
+    insta::assert_yaml_snapshot!(ast);
+}
+
+// ── ENRICH WITH ──────────────────────────────────────────────────────────────
+
+#[test]
+fn snapshot_enrich_with_logs() {
+    let ast =
+        parse("FROM traces WHERE status = 'ERROR' ENRICH WITH logs SINCE 1 hour ago").unwrap();
+    insta::assert_yaml_snapshot!(ast);
+}
+
+#[test]
+fn snapshot_enrich_with_limit() {
+    let ast =
+        parse("FROM traces WHERE status = 'ERROR' ENRICH WITH logs LIMIT 200 SINCE 1 hour ago")
+            .unwrap();
+    insta::assert_yaml_snapshot!(ast);
+}
+
+#[test]
+fn snapshot_enrich_with_sample_full() {
+    let ast = parse("FROM traces ENRICH WITH joint_states SAMPLE FULL SINCE 1 hour ago").unwrap();
+    insta::assert_yaml_snapshot!(ast);
+}
+
+#[test]
+fn snapshot_enrich_multiple() {
+    let ast = parse("SELECT * FROM traces WHERE status = 'ERROR' ENRICH WITH logs ENRICH WITH recordings SINCE 1 hour ago").unwrap();
+    insta::assert_yaml_snapshot!(ast);
+}

--- a/tests/snapshots/parse_compound__snapshot_show_node_graph.snap
+++ b/tests/snapshots/parse_compound__snapshot_show_node_graph.snap
@@ -1,29 +1,25 @@
 ---
-source: tests/parse_standard.rs
+source: tests/parse_compound.rs
 expression: ast
 ---
-Standard:
-  selections:
-    - Star
-  data_source: Logs
+Compound:
+  clause: ShowNodeGraph
   scope:
     robot:
       Single: robot_42
     version: ~
     environment: ~
     session: ~
-  conditions: ~
-  facet: ~
   time_range:
     Since:
       Relative:
-        amount: 1
-        unit: hour
+        amount: 30
+        unit: minutes
   time_basis: ~
+  conditions: ~
+  facet: ~
   order_by: ~
   limit: ~
   offset: ~
   output_format: ~
   baseline: ~
-  timeseries: ~
-  enrichments: []

--- a/tests/snapshots/parse_compound__snapshot_show_nodes.snap
+++ b/tests/snapshots/parse_compound__snapshot_show_nodes.snap
@@ -1,29 +1,25 @@
 ---
-source: tests/parse_standard.rs
+source: tests/parse_compound.rs
 expression: ast
 ---
-Standard:
-  selections:
-    - Star
-  data_source: Logs
+Compound:
+  clause: ShowNodes
   scope:
     robot:
       Single: robot_42
     version: ~
     environment: ~
     session: ~
-  conditions: ~
-  facet: ~
   time_range:
     Since:
       Relative:
-        amount: 1
-        unit: hour
+        amount: 30
+        unit: minutes
   time_basis: ~
+  conditions: ~
+  facet: ~
   order_by: ~
   limit: ~
   offset: ~
   output_format: ~
   baseline: ~
-  timeseries: ~
-  enrichments: []

--- a/tests/snapshots/parse_compound__snapshot_show_topics.snap
+++ b/tests/snapshots/parse_compound__snapshot_show_topics.snap
@@ -1,29 +1,25 @@
 ---
-source: tests/parse_standard.rs
+source: tests/parse_compound.rs
 expression: ast
 ---
-Standard:
-  selections:
-    - Star
-  data_source: Logs
+Compound:
+  clause: ShowTopics
   scope:
     robot:
       Single: robot_42
     version: ~
     environment: ~
     session: ~
-  conditions: ~
-  facet: ~
   time_range:
     Since:
       Relative:
         amount: 1
         unit: hour
   time_basis: ~
+  conditions: ~
+  facet: ~
   order_by: ~
   limit: ~
   offset: ~
   output_format: ~
   baseline: ~
-  timeseries: ~
-  enrichments: []

--- a/tests/snapshots/parse_compound__snapshot_show_topics_no_scope.snap
+++ b/tests/snapshots/parse_compound__snapshot_show_topics_no_scope.snap
@@ -1,0 +1,20 @@
+---
+source: tests/parse_compound.rs
+expression: ast
+---
+Compound:
+  clause: ShowTopics
+  scope: ~
+  time_range:
+    Since:
+      Relative:
+        amount: 6
+        unit: hours
+  time_basis: ~
+  conditions: ~
+  facet: ~
+  order_by: ~
+  limit: ~
+  offset: ~
+  output_format: ~
+  baseline: ~

--- a/tests/snapshots/parse_compound__snapshot_show_topics_where.snap
+++ b/tests/snapshots/parse_compound__snapshot_show_topics_where.snap
@@ -1,25 +1,24 @@
 ---
-source: tests/parse_standard.rs
+source: tests/parse_compound.rs
 expression: ast
 ---
-Standard:
-  selections:
-    - Star
-  data_source:
-    TopicAlias: Odom
+Compound:
+  clause: ShowTopics
   scope: ~
-  conditions: ~
-  facet: ~
   time_range:
     Since:
       Relative:
-        amount: 10
+        amount: 30
         unit: minutes
   time_basis: ~
+  conditions:
+    Like:
+      expr:
+        Field: topic_name
+      pattern: /camera%
+  facet: ~
   order_by: ~
   limit: ~
   offset: ~
   output_format: ~
   baseline: ~
-  timeseries: ~
-  enrichments: []

--- a/tests/snapshots/parse_pipeline__snapshot_pipeline_enrich_multiple.snap
+++ b/tests/snapshots/parse_pipeline__snapshot_pipeline_enrich_multiple.snap
@@ -1,0 +1,30 @@
+---
+source: tests/parse_pipeline.rs
+expression: ast
+---
+Pipeline:
+  stages:
+    - From: Traces
+    - Where:
+        Comparison:
+          left:
+            Field: status
+          op: Eq
+          right:
+            Literal:
+              String: ERROR
+    - EnrichWith:
+        source: Logs
+        join_key: ~
+        limit: ~
+        sample_full: false
+    - EnrichWith:
+        source: Recordings
+        join_key: ~
+        limit: ~
+        sample_full: false
+    - Since:
+        Since:
+          Relative:
+            amount: 1
+            unit: hour

--- a/tests/snapshots/parse_pipeline__snapshot_pipeline_enrich_with.snap
+++ b/tests/snapshots/parse_pipeline__snapshot_pipeline_enrich_with.snap
@@ -1,0 +1,25 @@
+---
+source: tests/parse_pipeline.rs
+expression: ast
+---
+Pipeline:
+  stages:
+    - From: Traces
+    - Where:
+        Comparison:
+          left:
+            Field: status
+          op: Eq
+          right:
+            Literal:
+              String: ERROR
+    - EnrichWith:
+        source: Logs
+        join_key: ~
+        limit: ~
+        sample_full: false
+    - Since:
+        Since:
+          Relative:
+            amount: 1
+            unit: hour

--- a/tests/snapshots/parse_pipeline__snapshot_pipeline_enrich_with_limit.snap
+++ b/tests/snapshots/parse_pipeline__snapshot_pipeline_enrich_with_limit.snap
@@ -1,0 +1,25 @@
+---
+source: tests/parse_pipeline.rs
+expression: ast
+---
+Pipeline:
+  stages:
+    - From: Traces
+    - Where:
+        Comparison:
+          left:
+            Field: status
+          op: Eq
+          right:
+            Literal:
+              String: ERROR
+    - EnrichWith:
+        source: Logs
+        join_key: ~
+        limit: 200
+        sample_full: false
+    - Since:
+        Since:
+          Relative:
+            amount: 1
+            unit: hour

--- a/tests/snapshots/parse_pipeline__snapshot_pipeline_timeseries.snap
+++ b/tests/snapshots/parse_pipeline__snapshot_pipeline_timeseries.snap
@@ -1,0 +1,26 @@
+---
+source: tests/parse_pipeline.rs
+expression: ast
+---
+Pipeline:
+  stages:
+    - From: Traces
+    - Where:
+        Comparison:
+          left:
+            Field: status
+          op: Eq
+          right:
+            Literal:
+              String: ERROR
+    - Timeseries:
+        interval:
+          raw_value: 5
+          unit: min
+          si_value: 300
+          si_unit: s
+    - Since:
+        Since:
+          Relative:
+            amount: 6
+            unit: hours

--- a/tests/snapshots/parse_pipeline__snapshot_pipeline_timeseries_with_facet.snap
+++ b/tests/snapshots/parse_pipeline__snapshot_pipeline_timeseries_with_facet.snap
@@ -1,0 +1,25 @@
+---
+source: tests/parse_pipeline.rs
+expression: ast
+---
+Pipeline:
+  stages:
+    - From: Traces
+    - Select:
+        - Aggregation:
+            function: Avg
+            args:
+              - Field: duration
+    - Timeseries:
+        interval:
+          raw_value: 1
+          unit: min
+          si_value: 60
+          si_unit: s
+    - Facet:
+        dimension: action_name
+    - Since:
+        Since:
+          Relative:
+            amount: 1
+            unit: hour

--- a/tests/snapshots/parse_standard__snapshot_aggregation_with_args.snap
+++ b/tests/snapshots/parse_standard__snapshot_aggregation_with_args.snap
@@ -21,3 +21,5 @@ Standard:
   offset: ~
   output_format: ~
   baseline: ~
+  timeseries: ~
+  enrichments: []

--- a/tests/snapshots/parse_standard__snapshot_basic_select.snap
+++ b/tests/snapshots/parse_standard__snapshot_basic_select.snap
@@ -17,3 +17,5 @@ Standard:
   offset: ~
   output_format: ~
   baseline: ~
+  timeseries: ~
+  enrichments: []

--- a/tests/snapshots/parse_standard__snapshot_between_timestamps.snap
+++ b/tests/snapshots/parse_standard__snapshot_between_timestamps.snap
@@ -21,3 +21,5 @@ Standard:
   offset: ~
   output_format: ~
   baseline: ~
+  timeseries: ~
+  enrichments: []

--- a/tests/snapshots/parse_standard__snapshot_bracket_access.snap
+++ b/tests/snapshots/parse_standard__snapshot_bracket_access.snap
@@ -25,3 +25,5 @@ Standard:
   offset: ~
   output_format: ~
   baseline: ~
+  timeseries: ~
+  enrichments: []

--- a/tests/snapshots/parse_standard__snapshot_composable_scope.snap
+++ b/tests/snapshots/parse_standard__snapshot_composable_scope.snap
@@ -25,3 +25,5 @@ Standard:
   offset: ~
   output_format: ~
   baseline: ~
+  timeseries: ~
+  enrichments: []

--- a/tests/snapshots/parse_standard__snapshot_enrich_multiple.snap
+++ b/tests/snapshots/parse_standard__snapshot_enrich_multiple.snap
@@ -1,0 +1,39 @@
+---
+source: tests/parse_standard.rs
+expression: ast
+---
+Standard:
+  selections:
+    - Star
+  data_source: Traces
+  scope: ~
+  conditions:
+    Comparison:
+      left:
+        Field: status
+      op: Eq
+      right:
+        Literal:
+          String: ERROR
+  facet: ~
+  time_range:
+    Since:
+      Relative:
+        amount: 1
+        unit: hour
+  time_basis: ~
+  order_by: ~
+  limit: ~
+  offset: ~
+  output_format: ~
+  baseline: ~
+  timeseries: ~
+  enrichments:
+    - source: Logs
+      join_key: ~
+      limit: ~
+      sample_full: false
+    - source: Recordings
+      join_key: ~
+      limit: ~
+      sample_full: false

--- a/tests/snapshots/parse_standard__snapshot_enrich_with_limit.snap
+++ b/tests/snapshots/parse_standard__snapshot_enrich_with_limit.snap
@@ -5,14 +5,16 @@ expression: ast
 Standard:
   selections:
     - Star
-  data_source: Logs
-  scope:
-    robot:
-      Single: robot_42
-    version: ~
-    environment: ~
-    session: ~
-  conditions: ~
+  data_source: Traces
+  scope: ~
+  conditions:
+    Comparison:
+      left:
+        Field: status
+      op: Eq
+      right:
+        Literal:
+          String: ERROR
   facet: ~
   time_range:
     Since:
@@ -26,4 +28,8 @@ Standard:
   output_format: ~
   baseline: ~
   timeseries: ~
-  enrichments: []
+  enrichments:
+    - source: Logs
+      join_key: ~
+      limit: 200
+      sample_full: false

--- a/tests/snapshots/parse_standard__snapshot_enrich_with_logs.snap
+++ b/tests/snapshots/parse_standard__snapshot_enrich_with_logs.snap
@@ -5,14 +5,16 @@ expression: ast
 Standard:
   selections:
     - Star
-  data_source: Logs
-  scope:
-    robot:
-      Single: robot_42
-    version: ~
-    environment: ~
-    session: ~
-  conditions: ~
+  data_source: Traces
+  scope: ~
+  conditions:
+    Comparison:
+      left:
+        Field: status
+      op: Eq
+      right:
+        Literal:
+          String: ERROR
   facet: ~
   time_range:
     Since:
@@ -26,4 +28,8 @@ Standard:
   output_format: ~
   baseline: ~
   timeseries: ~
-  enrichments: []
+  enrichments:
+    - source: Logs
+      join_key: ~
+      limit: ~
+      sample_full: false

--- a/tests/snapshots/parse_standard__snapshot_enrich_with_sample_full.snap
+++ b/tests/snapshots/parse_standard__snapshot_enrich_with_sample_full.snap
@@ -5,14 +5,15 @@ expression: ast
 Standard:
   selections:
     - Star
-  data_source: Logs
+  data_source: Traces
   scope: ~
   conditions: ~
   facet: ~
   time_range:
     Since:
-      Epoch:
-        Seconds: 1742306400
+      Relative:
+        amount: 1
+        unit: hour
   time_basis: ~
   order_by: ~
   limit: ~
@@ -20,4 +21,9 @@ Standard:
   output_format: ~
   baseline: ~
   timeseries: ~
-  enrichments: []
+  enrichments:
+    - source:
+        TopicAlias: JointStates
+      join_key: ~
+      limit: ~
+      sample_full: true

--- a/tests/snapshots/parse_standard__snapshot_for_session.snap
+++ b/tests/snapshots/parse_standard__snapshot_for_session.snap
@@ -24,3 +24,5 @@ Standard:
   offset: ~
   output_format: ~
   baseline: ~
+  timeseries: ~
+  enrichments: []

--- a/tests/snapshots/parse_standard__snapshot_from_shorthand.snap
+++ b/tests/snapshots/parse_standard__snapshot_from_shorthand.snap
@@ -16,3 +16,5 @@ Standard:
   offset: ~
   output_format: ~
   baseline: ~
+  timeseries: ~
+  enrichments: []

--- a/tests/snapshots/parse_standard__snapshot_full_query.snap
+++ b/tests/snapshots/parse_standard__snapshot_full_query.snap
@@ -48,3 +48,5 @@ Standard:
   offset: ~
   output_format: ~
   baseline: LastWeek
+  timeseries: ~
+  enrichments: []

--- a/tests/snapshots/parse_standard__snapshot_lifecycle_anchor.snap
+++ b/tests/snapshots/parse_standard__snapshot_lifecycle_anchor.snap
@@ -18,3 +18,5 @@ Standard:
   offset: ~
   output_format: ~
   baseline: ~
+  timeseries: ~
+  enrichments: []

--- a/tests/snapshots/parse_standard__snapshot_limit_offset.snap
+++ b/tests/snapshots/parse_standard__snapshot_limit_offset.snap
@@ -16,3 +16,5 @@ Standard:
   offset: 40
   output_format: ~
   baseline: ~
+  timeseries: ~
+  enrichments: []

--- a/tests/snapshots/parse_standard__snapshot_offset_only.snap
+++ b/tests/snapshots/parse_standard__snapshot_offset_only.snap
@@ -16,3 +16,5 @@ Standard:
   offset: 10
   output_format: ~
   baseline: ~
+  timeseries: ~
+  enrichments: []

--- a/tests/snapshots/parse_standard__snapshot_select_star.snap
+++ b/tests/snapshots/parse_standard__snapshot_select_star.snap
@@ -16,3 +16,5 @@ Standard:
   offset: ~
   output_format: ~
   baseline: ~
+  timeseries: ~
+  enrichments: []

--- a/tests/snapshots/parse_standard__snapshot_timeseries_1_hour.snap
+++ b/tests/snapshots/parse_standard__snapshot_timeseries_1_hour.snap
@@ -5,19 +5,25 @@ expression: ast
 Standard:
   selections:
     - Star
-  data_source: Logs
+  data_source: Traces
   scope: ~
   conditions: ~
   facet: ~
   time_range:
     Since:
-      Epoch:
-        Seconds: 1742306400
+      Relative:
+        amount: 24
+        unit: hours
   time_basis: ~
   order_by: ~
   limit: ~
   offset: ~
   output_format: ~
   baseline: ~
-  timeseries: ~
+  timeseries:
+    interval:
+      raw_value: 1
+      unit: h
+      si_value: 3600
+      si_unit: s
   enrichments: []

--- a/tests/snapshots/parse_standard__snapshot_timeseries_basic.snap
+++ b/tests/snapshots/parse_standard__snapshot_timeseries_basic.snap
@@ -1,0 +1,39 @@
+---
+source: tests/parse_standard.rs
+expression: ast
+---
+Standard:
+  selections:
+    - Aggregation:
+        function: Count
+        args:
+          - Field: "*"
+  data_source: Traces
+  scope: ~
+  conditions:
+    Comparison:
+      left:
+        Field: status
+      op: Eq
+      right:
+        Literal:
+          String: ERROR
+  facet: ~
+  time_range:
+    Since:
+      Relative:
+        amount: 6
+        unit: hours
+  time_basis: ~
+  order_by: ~
+  limit: ~
+  offset: ~
+  output_format: ~
+  baseline: ~
+  timeseries:
+    interval:
+      raw_value: 5
+      unit: min
+      si_value: 300
+      si_unit: s
+  enrichments: []

--- a/tests/snapshots/parse_standard__snapshot_timeseries_with_facet.snap
+++ b/tests/snapshots/parse_standard__snapshot_timeseries_with_facet.snap
@@ -4,16 +4,15 @@ expression: ast
 ---
 Standard:
   selections:
-    - Star
-  data_source: Logs
-  scope:
-    robot:
-      Single: robot_42
-    version: ~
-    environment: ~
-    session: ~
+    - Aggregation:
+        function: Avg
+        args:
+          - Field: duration
+  data_source: Traces
+  scope: ~
   conditions: ~
-  facet: ~
+  facet:
+    dimension: action_name
   time_range:
     Since:
       Relative:
@@ -25,5 +24,10 @@ Standard:
   offset: ~
   output_format: ~
   baseline: ~
-  timeseries: ~
+  timeseries:
+    interval:
+      raw_value: 1
+      unit: min
+      si_value: 60
+      si_unit: s
   enrichments: []

--- a/tests/snapshots/parse_standard__snapshot_where_in.snap
+++ b/tests/snapshots/parse_standard__snapshot_where_in.snap
@@ -24,3 +24,5 @@ Standard:
   offset: ~
   output_format: ~
   baseline: ~
+  timeseries: ~
+  enrichments: []


### PR DESCRIPTION
….4.2

TIMESERIES
- Parse: `TIMESERIES 5 min` in standard and pipeline forms; accepts SI abbreviations (min/h/s/ms) and English words (minutes/hours/seconds)
- Compile: time_bucket (DuckDB) / date_bin (PG) / FROM_UNIXTIME DIV (MySQL)
- Auto GROUP BY time_bucket, default ORDER BY time_bucket ASC
- Composes with FACET; exempt from default LIMIT 100 cap

ENRICH WITH
- Parse: `ENRICH WITH <source> [LIMIT N] [SAMPLE FULL]`; multiple allowed
- Compile: primary SQL unaffected; enrichment plans carried in CompileResult
- Execute: two-phase — extract join keys, ROW_NUMBER window SQL per source, merge enrichment rows as _enriched[source] JSON in result rows

SHOW TOPICS / SHOW NODES / SHOW NODE GRAPH
- SHOW TOPICS: topic_name, message_type, avg_rate_hz, publishers, subscribers, last_message_age_ms — grouped by ros.topic attribute
- SHOW NODES: node_name, topics_published, topics_subscribed, error_count, last_seen — grouped by ros.node attribute
- SHOW NODE GRAPH: (source_node, topic, target_node) edges for graph viz
- All three accept FOR ROBOT / SINCE scoping

Bug fixes
- SINCE 30 min ago now parses correctly — short SI abbreviations (min, h, s, ms, ns, d, w) were missing from the time-unit recogniser
- DuckDB json_access_text() wraps in CAST(... AS VARCHAR) to avoid type-cast errors in WHERE IS NOT NULL / ORDER BY / DISTINCT contexts

Also: completions updated, examples + README + cookbook, CHANGELOG 0.4.0–0.4.2