### PR TITLE
fix(#74): WITHIN proto serialization — add WithinCondition to ast.proto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.8] - 2026-04-15
+
+### Fixed
+
+- **`WITHIN` proto serialization** — `Condition::Within` (both `GPS` and `Local` center variants) is now fully serialized to protobuf instead of silently falling back to a `IsNotNull` stub. Added `WithinCondition`, `GpsCenter`, and `LocalCenter` messages to `ast.proto` and wired them into `condition_to_proto` in `convert.rs`. Two new unit tests (`convert_within_gps`, `convert_within_local`) cover both variants. Closes #74.
+
 ## [0.4.7] - 2026-04-15
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3253,7 +3253,7 @@ dependencies = [
 
 [[package]]
 name = "rosql"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "async-trait",
  "aws-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ exclude = ["examples"]
 
 [package]
 name = "rosql"
-version = "0.4.7"
+version = "0.4.8"
 edition = "2021"
 rust-version = "1.80"
 license = "Apache-2.0"

--- a/proto/rosql/v1/ast.proto
+++ b/proto/rosql/v1/ast.proto
@@ -238,6 +238,7 @@ message Condition {
     InExpr in_expr = 7;
     LikeExpr like = 8;
     BetweenExpr between = 9;
+    WithinCondition within = 10;
   }
 }
 
@@ -266,6 +267,25 @@ message BetweenExpr {
   Expr expr = 1;
   Expr low = 2;
   Expr high = 3;
+}
+
+message WithinCondition {
+  Expr field = 1;
+  UnitValue radius = 2;
+  oneof center {
+    GpsCenter gps = 3;
+    LocalCenter local = 4;
+  }
+}
+
+message GpsCenter {
+  double lat = 1;
+  double lon = 2;
+}
+
+message LocalCenter {
+  double x = 1;
+  double y = 2;
 }
 
 enum ComparisonOp {

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -320,9 +320,28 @@ fn condition_to_proto(cond: &ast::Condition) -> pb::Condition {
                 high: Some(expr_to_proto(high)),
             })
         }
-        // WITHIN geospatial condition — proto not yet defined; fall back to a stub.
-        // TODO: add WithinCondition to ast.proto for full proto round-trip support.
-        ast::Condition::Within { .. } => pb::condition::Condition::IsNotNull(pb::Expr::default()),
+        ast::Condition::Within {
+            field,
+            radius,
+            center,
+        } => {
+            let center_oneof = match center {
+                ast::GeospatialCenter::Gps(lat, lon) => {
+                    pb::within_condition::Center::Gps(pb::GpsCenter {
+                        lat: *lat,
+                        lon: *lon,
+                    })
+                }
+                ast::GeospatialCenter::Local(x, y) => {
+                    pb::within_condition::Center::Local(pb::LocalCenter { x: *x, y: *y })
+                }
+            };
+            pb::condition::Condition::Within(pb::WithinCondition {
+                field: Some(expr_to_proto(field)),
+                radius: Some(unit_value_to_proto(radius)),
+                center: Some(center_oneof),
+            })
+        }
     };
     pb::Condition {
         condition: Some(cond_oneof),
@@ -692,6 +711,60 @@ mod tests {
                 }
             }
             _ => panic!("expected Compound"),
+        }
+    }
+
+    #[test]
+    fn convert_within_gps() {
+        let ast = parse("FROM traces WHERE position WITHIN 50 m OF (37.7749, -122.4194)").unwrap();
+        let proto = query_to_proto(&ast);
+        match proto.query.unwrap() {
+            pb::rosql_query::Query::Standard(sq) => {
+                let cond = sq.conditions.unwrap().condition.unwrap();
+                match cond {
+                    pb::condition::Condition::Within(w) => {
+                        assert!(w.field.is_some());
+                        let radius = w.radius.unwrap();
+                        assert_eq!(radius.raw_value, 50.0);
+                        match w.center.unwrap() {
+                            pb::within_condition::Center::Gps(g) => {
+                                assert!((g.lat - 37.7749).abs() < 1e-6);
+                                assert!((g.lon - -122.4194).abs() < 1e-6);
+                            }
+                            _ => panic!("expected GPS center"),
+                        }
+                    }
+                    _ => panic!("expected Within condition"),
+                }
+            }
+            _ => panic!("expected Standard"),
+        }
+    }
+
+    #[test]
+    fn convert_within_local() {
+        let ast = parse("FROM traces WHERE position WITHIN 5 m OF POSITION (10.0, 20.0)").unwrap();
+        let proto = query_to_proto(&ast);
+        match proto.query.unwrap() {
+            pb::rosql_query::Query::Standard(sq) => {
+                let cond = sq.conditions.unwrap().condition.unwrap();
+                match cond {
+                    pb::condition::Condition::Within(w) => {
+                        assert!(w.field.is_some());
+                        let radius = w.radius.unwrap();
+                        assert_eq!(radius.raw_value, 5.0);
+                        match w.center.unwrap() {
+                            pb::within_condition::Center::Local(l) => {
+                                assert!((l.x - 10.0).abs() < 1e-6);
+                                assert!((l.y - 20.0).abs() < 1e-6);
+                            }
+                            _ => panic!("expected Local center"),
+                        }
+                    }
+                    _ => panic!("expected Within condition"),
+                }
+            }
+            _ => panic!("expected Standard"),
         }
     }
 }


### PR DESCRIPTION
Add WithinCondition, GpsCenter, and LocalCenter proto messages and wire them into condition_to_proto, replacing the IsNotNull stub that silently dropped WITHIN clauses. Covers both GPS (Haversine) and Local (Euclidean) center variants with two new unit tests. Bumps to v0.4.8.