### PR TITLE
feat(#47): CLI polish, macOS Intel build, and Homebrew tap distribution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,9 @@ jobs:
           - target: aarch64-unknown-linux-gnu
             runner: ubuntu-24.04-arm
           - target: aarch64-apple-darwin
-            runner: macos-14
+            runner: macos-latest
+          - target: x86_64-apple-darwin
+            runner: macos-13
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -100,6 +102,73 @@ jobs:
         run: |
           gh release upload "${{ needs.create-release.outputs.tag }}" \
             rosql-${{ needs.create-release.outputs.version }}-${{ matrix.target }}.tar.gz
+
+  update-homebrew-tap:
+    name: Update Homebrew tap
+    needs: [create-release, build-binaries]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download macOS tarballs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ needs.create-release.outputs.version }}"
+          TAG="${{ needs.create-release.outputs.tag }}"
+          gh release download "$TAG" \
+            --repo RobotOpsInc/rosql \
+            --pattern "rosql-${VERSION}-aarch64-apple-darwin.tar.gz" \
+            --pattern "rosql-${VERSION}-x86_64-apple-darwin.tar.gz"
+
+      - name: Compute SHA256 checksums
+        run: |
+          VERSION="${{ needs.create-release.outputs.version }}"
+          ARM_SHA=$(sha256sum "rosql-${VERSION}-aarch64-apple-darwin.tar.gz" | awk '{print $1}')
+          INTEL_SHA=$(sha256sum "rosql-${VERSION}-x86_64-apple-darwin.tar.gz" | awk '{print $1}')
+          echo "ARM_SHA=$ARM_SHA" >> "$GITHUB_ENV"
+          echo "INTEL_SHA=$INTEL_SHA" >> "$GITHUB_ENV"
+
+      - name: Clone homebrew-tap
+        env:
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          git clone "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/RobotOpsInc/homebrew-tap.git" tap
+
+      - name: Update formula
+        run: |
+          VERSION="${{ needs.create-release.outputs.version }}"
+          FORMULA="tap/Formula/rosql.rb"
+
+          # Update version
+          sed -i "s/version \".*\"/version \"${VERSION}\"/" "$FORMULA"
+
+          # Update ARM SHA256 (line after the aarch64 url)
+          sed -i "/aarch64-apple-darwin/,/sha256/{s/sha256 \".*\"/sha256 \"${ARM_SHA}\"/}" "$FORMULA"
+
+          # Update Intel SHA256 (line after the x86_64 url)
+          sed -i "/x86_64-apple-darwin/,/sha256/{s/sha256 \".*\"/sha256 \"${INTEL_SHA}\"/}" "$FORMULA"
+
+      - name: Open PR on homebrew-tap
+        env:
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          VERSION="${{ needs.create-release.outputs.version }}"
+          BRANCH="bump-rosql-${VERSION}"
+
+          cd tap
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add Formula/rosql.rb
+          git commit -m "rosql ${VERSION}"
+          git push origin "$BRANCH"
+
+          gh pr create \
+            --repo RobotOpsInc/homebrew-tap \
+            --title "rosql ${VERSION}" \
+            --body "Automated formula bump for rosql ${VERSION}." \
+            --base main \
+            --head "$BRANCH"
 
   publish-crate:
     name: Publish to crates.io

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.9] - 2026-04-15
+
+### Added
+
+- **macOS Intel (x86_64) binary** — pre-built tarballs for `x86_64-apple-darwin` are now published to GitHub Releases on every release. `install.sh` and the Homebrew formula cover all four targets: Linux x86_64, Linux arm64, macOS Intel, macOS Apple Silicon.
+- **Homebrew tap** — `brew install robotopsinc/tap/rosql` is now the recommended macOS install method. The release workflow automatically opens a bump PR on `RobotOpsInc/homebrew-tap` after each release.
+- **`rosql query` table output** — results now render as a human-readable aligned table by default. Use `--format json` to get the previous JSON output, or `--format csv` for export. Row count and execution time are printed to stderr.
+- **`rosql schema` subcommand** — connects to a backend and reports which canonical OTel data sources (`traces`, `logs`, `metrics`, `topics`, `recordings`) are available.
+- **`--file <path>`** flag on `parse`, `compile`, `query`, `validate` — read the query from a `.rosql` file instead of a positional argument.
+- **`--no-color`** global flag — disable ANSI color codes. Color is also auto-disabled when stdout is not a TTY.
+- **`ROSQL_BACKEND`, `ROSQL_URL`, `ROSQL_SCHEMA` environment variables** — set default values for the corresponding flags.
+- **`~/.config/rosql/config.toml`** — persistent per-user defaults for `backend`, `url`, and `schema`. Precedence: CLI flag > env var > config file > built-in default.
+
+### Changed
+
+- **`rosql query` default output format changed from JSON to table** — this is a breaking change for scripts that rely on the JSON output. Replace `rosql query ...` with `rosql query ... --format json` to restore the previous behavior.
+
 ## [0.4.8] - 2026-04-15
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -964,6 +964,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1054,7 +1060,7 @@ version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -1082,13 +1088,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "colored"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
+dependencies = [
+ "lazy_static",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "comfy-table"
 version = "7.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
 dependencies = [
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -1276,6 +1292,27 @@ dependencies = [
  "const-oid",
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1746,6 +1783,12 @@ checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
  "hashbrown 0.15.5",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -2588,10 +2631,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
+name = "papergrid"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7419ad52a7de9b60d33e11085a0fe3df1fbd5926aa3f93d3dd53afbc9e86725"
+dependencies = [
+ "bytecount",
+ "fnv",
+ "unicode-width 0.1.11",
+]
 
 [[package]]
 name = "parking"
@@ -2772,7 +2832,31 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.25.8+spec-1.1.0",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -2830,7 +2914,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
- "heck",
+ "heck 0.5.0",
  "itertools 0.12.1",
  "log",
  "multimap",
@@ -2852,7 +2936,7 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -3125,6 +3209,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3253,13 +3348,15 @@ dependencies = [
 
 [[package]]
 name = "rosql"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "async-trait",
  "aws-config",
  "aws-sdk-athena",
  "chrono",
  "clap",
+ "colored",
+ "dirs",
  "duckdb",
  "gcp-bigquery-client",
  "getrandom 0.3.4",
@@ -3277,10 +3374,12 @@ dependencies = [
  "serde_json",
  "sqlx",
  "strsim",
+ "tabled",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
+ "toml",
  "tonic 0.12.3",
  "tonic-build 0.12.3",
  "wasm-bindgen",
@@ -3630,6 +3729,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3830,7 +3938,7 @@ checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
 dependencies = [
  "dotenvy",
  "either",
- "heck",
+ "heck 0.5.0",
  "hex",
  "once_cell",
  "proc-macro2",
@@ -3991,7 +4099,7 @@ version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -4049,6 +4157,29 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tabled"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77c9303ee60b9bedf722012ea29ae3711ba13a67c9b9ae28993838b63057cb1b"
+dependencies = [
+ "papergrid",
+ "tabled_derive",
+]
+
+[[package]]
+name = "tabled_derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf0fb8bfdc709786c154e24a66777493fb63ae97e3036d914c8666774c477069"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4281,6 +4412,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4291,14 +4443,28 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap 2.13.0",
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.25.8+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16bff38f1d86c47f9ff0647e6838d7bb362522bdf44006c7068c2b1e606f1f3c"
 dependencies = [
  "indexmap 2.13.0",
- "toml_datetime",
+ "toml_datetime 1.1.0+spec-1.1.0",
  "toml_parser",
- "winnow",
+ "winnow 1.0.0",
 ]
 
 [[package]]
@@ -4307,8 +4473,14 @@ version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
 dependencies = [
- "winnow",
+ "winnow 1.0.0",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tonic"
@@ -4551,6 +4723,12 @@ name = "unicode-segmentation"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da36089a805484bcccfffe0739803392c8298778a2d2f09febf76fac5ad9025b"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
 name = "unicode-width"
@@ -5158,6 +5336,15 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
@@ -5181,7 +5368,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.5.0",
  "wit-parser",
 ]
 
@@ -5192,7 +5379,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.5.0",
  "indexmap 2.13.0",
  "prettyplease",
  "syn 2.0.117",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ exclude = ["examples"]
 
 [package]
 name = "rosql"
-version = "0.4.8"
+version = "0.4.9"
 edition = "2021"
 rust-version = "1.80"
 license = "Apache-2.0"
@@ -23,7 +23,7 @@ required-features = ["server"]
 [features]
 default = []
 wasm = ["dep:wasm-bindgen", "dep:serde-wasm-bindgen"]
-server = ["dep:tonic", "dep:tokio", "dep:clap", "dep:tokio-stream"]
+server = ["dep:tonic", "dep:tokio", "dep:clap", "dep:tokio-stream", "dep:tabled", "dep:colored", "dep:dirs", "dep:toml"]
 postgres = ["dep:sqlx", "dep:tokio"]
 mysql = ["dep:sqlx", "dep:tokio"]
 duckdb = ["dep:duckdb", "dep:tokio"]
@@ -45,7 +45,11 @@ prost-types = "0.13"
 wasm-bindgen = { version = "0.2", optional = true }
 serde-wasm-bindgen = { version = "0.6", optional = true }
 tonic = { version = "0.12", optional = true }
-clap = { version = "4", optional = true, features = ["derive"] }
+clap = { version = "4", optional = true, features = ["derive", "env"] }
+tabled = { version = "0.16", optional = true }
+colored = { version = "2", optional = true }
+dirs = { version = "5", optional = true }
+toml = { version = "0.8", optional = true }
 sqlx = { version = "0.8", optional = true, features = ["runtime-tokio", "postgres", "mysql", "chrono", "json"] }
 tokio = { version = "1", optional = true, features = ["rt-multi-thread", "macros", "net"] }
 tokio-stream = { version = "0.1", optional = true, features = ["net"] }

--- a/README.md
+++ b/README.md
@@ -112,8 +112,10 @@ TRACE 'a3f1c9d2e8b04f7a'
 ### As a CLI
 
 ```sh
-# Install (Linux x86_64 / arm64, macOS Apple Silicon)
+# Install (Linux x86_64 / arm64, macOS Intel & Apple Silicon)
 curl -fsSL https://rosql.org/install.sh | sh
+# Or on macOS via Homebrew (supports brew upgrade)
+brew install robotopsinc/tap/rosql
 
 # Or build from source (all platforms)
 cargo install rosql --features server,duckdb
@@ -353,11 +355,19 @@ See [BENCHMARKS.md](BENCHMARKS.md) for performance data (coming soon — [#35](h
 
 ## Installation
 
-### One-liner (Linux x86_64 / arm64, macOS Apple Silicon)
+### One-liner (Linux x86_64 / arm64, macOS Intel &amp; Apple Silicon)
 
 ```sh
 curl -fsSL https://rosql.org/install.sh | sh
 ```
+
+### Homebrew (macOS)
+
+```sh
+brew install robotopsinc/tap/rosql
+```
+
+Supports `brew upgrade rosql` and `brew uninstall rosql`.
 
 Pre-built binaries include the Parquet backend (`--backend parquet`) and are available for:
 
@@ -366,7 +376,7 @@ Pre-built binaries include the Parquet backend (`--backend parquet`) and are ava
 | Linux | x86_64 | — |
 | Linux | aarch64 | — |
 | macOS | arm64 (Apple Silicon) | — |
-| macOS | x86_64 (Intel) | Build from source (see below) |
+| macOS | x86_64 (Intel) | — |
 | Windows | any | Build from source (see below) |
 
 ### Build from source

--- a/install.sh
+++ b/install.sh
@@ -11,9 +11,9 @@
 #   Linux  x86_64     (x86_64-unknown-linux-gnu)
 #   Linux  arm64      (aarch64-unknown-linux-gnu)
 #   macOS  arm64      (aarch64-apple-darwin)      — Apple Silicon
+#   macOS  x86_64     (x86_64-apple-darwin)       — Intel Mac
 #
 # Unsupported platforms (build from source):
-#   macOS  x86_64     (Intel Mac)
 #   Windows            (any arch)
 #
 # To build from source on any platform:
@@ -45,11 +45,7 @@ case "$OS" in
   Darwin*)
     case "$ARCH" in
       arm64)    TARGET="aarch64-apple-darwin" ;;
-      x86_64)
-        echo "Error: pre-built binaries are not available for Intel Macs."
-        echo "Build from source: cargo install rosql --features server,duckdb"
-        exit 1
-        ;;
+      x86_64)   TARGET="x86_64-apple-darwin" ;;
       *)
         echo "Error: unsupported macOS architecture: $ARCH"
         echo "Build from source: cargo install rosql --features server,duckdb"

--- a/src/bin/rosql.rs
+++ b/src/bin/rosql.rs
@@ -2,24 +2,81 @@
 //!
 //! Build with: `cargo build --features server --bin rosql`
 //! For query execution: `cargo build --features server,postgres --bin rosql`
+//!                      `cargo build --features server,duckdb --bin rosql`
 //!
 //! Usage:
 //!   rosql parse <query>                          # parse → JSON AST
 //!   rosql compile <query> --backend <type>       # parse → compiled SQL
 //!   rosql query <query> --backend <type> --url   # parse → execute → results
 //!   rosql validate <query>                       # validate syntax
+//!   rosql schema --backend <type> --url          # inspect available data sources
 //!   rosql completions <query> <pos>              # autocomplete
 //!   rosql serve [--socket <path>]                # gRPC server
 
 use clap::{Parser, Subcommand, ValueEnum};
-use std::io::{self, Read};
+use std::io::{self, IsTerminal, Read};
+
+// ---------------------------------------------------------------------------
+// Config file — ~/.config/rosql/config.toml
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Default, serde::Deserialize)]
+struct Config {
+    default: Option<ConfigDefaults>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct ConfigDefaults {
+    backend: Option<String>,
+    url: Option<String>,
+    schema: Option<String>,
+}
+
+fn load_config() -> Config {
+    let Some(config_dir) = dirs::config_dir() else {
+        return Config::default();
+    };
+    let path = config_dir.join("rosql").join("config.toml");
+    let Ok(content) = std::fs::read_to_string(&path) else {
+        return Config::default();
+    };
+    toml::from_str(&content).unwrap_or_default()
+}
+
+fn config_backend(config: &Config) -> Option<Backend> {
+    let s = config.default.as_ref()?.backend.as_deref()?;
+    match s.to_lowercase().as_str() {
+        "postgres" | "postgresql" => Some(Backend::Postgres),
+        "mysql" | "mariadb" => Some(Backend::Mysql),
+        "parquet" | "duckdb" => Some(Backend::Parquet),
+        _ => None,
+    }
+}
+
+fn config_schema(config: &Config) -> Option<Schema> {
+    let s = config.default.as_ref()?.schema.as_deref()?;
+    match s.to_lowercase().as_str() {
+        "otel-postgres" | "otel_postgres" => Some(Schema::OtelPostgres),
+        "otel-clickhouse" | "otel_clickhouse" => Some(Schema::OtelClickhouse),
+        _ => None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CLI types
+// ---------------------------------------------------------------------------
 
 #[derive(Parser)]
 #[command(
     name = "rosql",
-    about = "ROSQL — parse, compile, and execute ROS2 telemetry queries"
+    about = "ROSQL — parse, compile, and execute ROS2 telemetry queries",
+    version
 )]
 struct Cli {
+    /// Disable ANSI color codes in all output.
+    #[arg(long, global = true)]
+    no_color: bool,
+
     #[command(subcommand)]
     command: Commands,
 }
@@ -30,6 +87,10 @@ enum Commands {
     Parse {
         /// The ROSQL query string. Reads from stdin if omitted.
         query: Option<String>,
+
+        /// Read the query from a file instead of a positional argument.
+        #[arg(long)]
+        file: Option<std::path::PathBuf>,
     },
 
     /// Compile a ROSQL query to SQL for a specific backend.
@@ -37,13 +98,16 @@ enum Commands {
         /// The ROSQL query string. Reads from stdin if omitted.
         query: Option<String>,
 
+        /// Read the query from a file instead of a positional argument.
+        #[arg(long)]
+        file: Option<std::path::PathBuf>,
+
         /// Target database backend.
-        #[arg(long, default_value = "postgres")]
+        #[arg(long, default_value = "postgres", env = "ROSQL_BACKEND")]
         backend: Backend,
 
         /// Schema profile — determines column naming convention.
-        /// Defaults to otel-postgres for postgres/mysql/sqlite backends.
-        #[arg(long, default_value = "otel-postgres")]
+        #[arg(long, default_value = "otel-postgres", env = "ROSQL_SCHEMA")]
         schema: Schema,
     },
 
@@ -52,26 +116,53 @@ enum Commands {
         /// The ROSQL query string. Reads from stdin if omitted.
         query: Option<String>,
 
-        /// Target database backend.
+        /// Read the query from a file instead of a positional argument.
         #[arg(long)]
-        backend: Backend,
+        file: Option<std::path::PathBuf>,
+
+        /// Target database backend.
+        #[arg(long, env = "ROSQL_BACKEND")]
+        backend: Option<Backend>,
 
         /// Schema profile — determines column naming convention.
-        #[arg(long, default_value = "otel-postgres")]
-        schema: Schema,
+        #[arg(long, env = "ROSQL_SCHEMA")]
+        schema: Option<Schema>,
 
         /// Database connection URL.
         /// PostgreSQL: postgresql://user:pass@host:5432/db
-        /// SQLite: sqlite:./path/to/db
-        /// MySQL: mysql://user:pass@host:3306/db
-        #[arg(long)]
-        url: String,
+        /// Parquet:    /path/to/telemetry/  or  s3://bucket/prefix/
+        /// MySQL:      mysql://user:pass@host:3306/db
+        #[arg(long, env = "ROSQL_URL")]
+        url: Option<String>,
+
+        /// Output format.
+        #[arg(long, default_value = "table")]
+        format: CliFormat,
     },
 
     /// Validate a ROSQL query.
     Validate {
         /// The ROSQL query string. Reads from stdin if omitted.
         query: Option<String>,
+
+        /// Read the query from a file instead of a positional argument.
+        #[arg(long)]
+        file: Option<std::path::PathBuf>,
+    },
+
+    /// Inspect available data sources on the connected backend.
+    SchemaCmd {
+        /// Target database backend.
+        #[arg(long, env = "ROSQL_BACKEND")]
+        backend: Option<Backend>,
+
+        /// Database connection URL.
+        #[arg(long, env = "ROSQL_URL")]
+        url: Option<String>,
+
+        /// Output format.
+        #[arg(long, default_value = "table")]
+        format: CliFormat,
     },
 
     /// Get completions at a cursor position.
@@ -92,6 +183,17 @@ enum Commands {
         #[arg(long, default_value = "info")]
         log_level: String,
     },
+}
+
+/// Output format for `query` and `schema` subcommands.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+enum CliFormat {
+    /// Human-readable aligned table (default).
+    Table,
+    /// JSON output for programmatic consumption.
+    Json,
+    /// CSV output.
+    Csv,
 }
 
 /// Schema profile — column naming convention for the OTel exporter.
@@ -144,35 +246,56 @@ impl Backend {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
 #[tokio::main]
 async fn main() {
     let cli = Cli::parse();
+    let no_color = cli.no_color || !io::stdout().is_terminal();
+    let config = load_config();
 
     match cli.command {
-        Commands::Parse { query } => {
-            let query = read_query(query);
+        Commands::Parse { query, file } => {
+            let query = read_query(query, file);
             cmd_parse(&query);
         }
         Commands::Compile {
             query,
+            file,
             backend,
             schema,
         } => {
-            let query = read_query(query);
+            let query = read_query(query, file);
             cmd_compile(&query, backend, schema);
         }
         Commands::Query {
             query,
+            file,
             backend,
             schema,
             url,
+            format,
         } => {
-            let query = read_query(query);
-            cmd_query(&query, backend, schema, &url).await;
+            let query = read_query(query, file);
+            let backend = resolve_backend(backend, &config);
+            let url = resolve_url(url, &config);
+            let schema = resolve_schema(schema, &config);
+            cmd_query(&query, backend, schema, &url, format, no_color).await;
         }
-        Commands::Validate { query } => {
-            let query = read_query(query);
+        Commands::Validate { query, file } => {
+            let query = read_query(query, file);
             cmd_validate(&query);
+        }
+        Commands::SchemaCmd {
+            backend,
+            url,
+            format,
+        } => {
+            let backend = resolve_backend(backend, &config);
+            let url = resolve_url(url, &config);
+            cmd_schema(backend, &url, format, no_color).await;
         }
         Commands::Completions { query, cursor_pos } => {
             cmd_completions(&query, cursor_pos);
@@ -181,6 +304,38 @@ async fn main() {
             serve(socket, log_level).await;
         }
     }
+}
+
+// ---------------------------------------------------------------------------
+// Config resolution helpers
+// ---------------------------------------------------------------------------
+
+fn resolve_backend(cli_backend: Option<Backend>, config: &Config) -> Backend {
+    cli_backend
+        .or_else(|| config_backend(config))
+        .unwrap_or_else(|| {
+            eprintln!(
+                "Error: --backend is required (or set ROSQL_BACKEND, or add to ~/.config/rosql/config.toml)"
+            );
+            std::process::exit(1);
+        })
+}
+
+fn resolve_url(cli_url: Option<String>, config: &Config) -> String {
+    cli_url
+        .or_else(|| config.default.as_ref().and_then(|d| d.url.clone()))
+        .unwrap_or_else(|| {
+            eprintln!(
+                "Error: --url is required (or set ROSQL_URL, or add to ~/.config/rosql/config.toml)"
+            );
+            std::process::exit(1);
+        })
+}
+
+fn resolve_schema(cli_schema: Option<Schema>, config: &Config) -> Schema {
+    cli_schema
+        .or_else(|| config_schema(config))
+        .unwrap_or(Schema::OtelPostgres)
 }
 
 // ---------------------------------------------------------------------------
@@ -247,12 +402,18 @@ fn cmd_compile(query: &str, backend: Backend, schema: Schema) {
 }
 
 #[allow(unused_variables)]
-async fn cmd_query(query: &str, backend: Backend, _schema: Schema, url: &str) {
+async fn cmd_query(
+    query: &str,
+    backend: Backend,
+    schema: Schema,
+    url: &str,
+    format: CliFormat,
+    no_color: bool,
+) {
     #[cfg(any(feature = "postgres", feature = "mysql", feature = "duckdb"))]
     {
         use rosql::drivers::ROSQLBackend;
 
-        // Validate backend is supported (errors out on Athena/BigQuery).
         if let Err(msg) = backend.to_dialect() {
             eprintln!("Error: {msg}");
             std::process::exit(1);
@@ -287,8 +448,7 @@ async fn cmd_query(query: &str, backend: Backend, _schema: Schema, url: &str) {
         let opts = rosql::ExecOptions::default();
         match sql_backend.execute(&ast, &opts).await {
             Ok(result) => {
-                let json = serde_json::to_string_pretty(&result).unwrap();
-                println!("{json}");
+                print_result(&result, format, no_color);
             }
             Err(err) => {
                 let json = serde_json::json!({
@@ -338,10 +498,241 @@ fn cmd_validate(query: &str) {
     }
 }
 
+#[allow(unused_variables)]
+async fn cmd_schema(backend: Backend, url: &str, format: CliFormat, no_color: bool) {
+    #[cfg(any(feature = "postgres", feature = "mysql", feature = "duckdb"))]
+    {
+        if let Err(msg) = backend.to_dialect() {
+            eprintln!("Error: {msg}");
+            std::process::exit(1);
+        }
+
+        let sql_backend = match backend {
+            #[cfg(feature = "duckdb")]
+            Backend::Parquet => match rosql::drivers::sql::SqlBackend::from_parquet(url).await {
+                Ok(b) => b,
+                Err(err) => {
+                    eprintln!("Parquet backend error: {err}");
+                    std::process::exit(1);
+                }
+            },
+            _ => match rosql::drivers::sql::SqlBackend::new(url).await {
+                Ok(b) => b,
+                Err(err) => {
+                    eprintln!("Connection error: {err}");
+                    std::process::exit(1);
+                }
+            },
+        };
+
+        use rosql::drivers::ROSQLBackend;
+
+        // Probe each canonical data source via a LIMIT 0 ROSQL query.
+        let sources = [
+            ("traces", "otel_traces"),
+            ("logs", "otel_logs"),
+            ("metrics", "otel_metrics"),
+            ("topics", "topic_messages"),
+            ("recordings", "mcap_metadata"),
+        ];
+
+        struct SourceRow {
+            rosql_source: &'static str,
+            table: &'static str,
+            status: &'static str,
+        }
+
+        let mut rows: Vec<SourceRow> = Vec::new();
+        for (rosql_source, table) in sources {
+            let probe = format!("FROM {rosql_source} LIMIT 0");
+            let status = match rosql::parse(&probe) {
+                Ok(ast) => {
+                    let opts = rosql::ExecOptions::default();
+                    if sql_backend.execute(&ast, &opts).await.is_ok() {
+                        "available"
+                    } else {
+                        "not found"
+                    }
+                }
+                Err(_) => "not found",
+            };
+            rows.push(SourceRow {
+                rosql_source,
+                table,
+                status,
+            });
+        }
+
+        match format {
+            CliFormat::Json => {
+                let json_rows: Vec<serde_json::Value> = rows
+                    .iter()
+                    .map(|r| {
+                        serde_json::json!({
+                            "source": r.rosql_source,
+                            "table": r.table,
+                            "status": r.status,
+                        })
+                    })
+                    .collect();
+                println!("{}", serde_json::to_string_pretty(&json_rows).unwrap());
+            }
+            CliFormat::Csv => {
+                println!("source,table,status");
+                for r in &rows {
+                    println!("{},{},{}", r.rosql_source, r.table, r.status);
+                }
+            }
+            CliFormat::Table => {
+                use colored::Colorize;
+                use tabled::{Table, Tabled};
+
+                #[derive(Tabled)]
+                struct Row {
+                    #[tabled(rename = "Source")]
+                    source: String,
+                    #[tabled(rename = "Table")]
+                    table: String,
+                    #[tabled(rename = "Status")]
+                    status: String,
+                }
+
+                let table_rows: Vec<Row> = rows
+                    .iter()
+                    .map(|r| Row {
+                        source: r.rosql_source.to_string(),
+                        table: r.table.to_string(),
+                        status: if no_color {
+                            r.status.to_string()
+                        } else if r.status == "available" {
+                            r.status.green().to_string()
+                        } else {
+                            r.status.dimmed().to_string()
+                        },
+                    })
+                    .collect();
+
+                let table = Table::new(table_rows);
+                println!("{table}");
+            }
+        }
+    }
+
+    #[cfg(not(any(feature = "postgres", feature = "mysql", feature = "duckdb")))]
+    {
+        eprintln!(
+            "Error: the `schema` subcommand requires a database driver feature.\n\
+             Rebuild with one of:\n\
+             cargo build --features server,postgres --bin rosql\n\
+             cargo build --features server,duckdb --bin rosql"
+        );
+        std::process::exit(1);
+    }
+}
+
 fn cmd_completions(query: &str, cursor_pos: usize) {
     let completions = rosql::completions::get_completions(query, cursor_pos);
     let json = serde_json::to_string_pretty(&completions).unwrap();
     println!("{json}");
+}
+
+// ---------------------------------------------------------------------------
+// Output rendering
+// ---------------------------------------------------------------------------
+
+#[cfg(any(feature = "postgres", feature = "mysql", feature = "duckdb"))]
+fn print_result(result: &rosql::drivers::ROSQLResult, format: CliFormat, no_color: bool) {
+    match format {
+        CliFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(result).unwrap());
+        }
+        CliFormat::Csv => {
+            print_csv(result);
+        }
+        CliFormat::Table => {
+            print_table(result, no_color);
+        }
+    }
+}
+
+#[cfg(any(feature = "postgres", feature = "mysql", feature = "duckdb"))]
+fn print_table(result: &rosql::drivers::ROSQLResult, no_color: bool) {
+    use tabled::{
+        builder::Builder,
+        settings::{object::Rows, Color, Modify, Style},
+    };
+
+    if result.rows.is_empty() {
+        eprintln!("(0 rows)");
+        return;
+    }
+
+    let headers: Vec<String> = result.columns.iter().map(|c| c.name.clone()).collect();
+
+    let mut builder = Builder::default();
+    builder.push_record(headers);
+
+    for row in &result.rows {
+        let cells: Vec<String> = row
+            .iter()
+            .map(|v| match v {
+                serde_json::Value::String(s) => s.clone(),
+                serde_json::Value::Null => String::new(),
+                other => other.to_string(),
+            })
+            .collect();
+        builder.push_record(cells);
+    }
+
+    let mut table = builder.build();
+    table.with(Style::rounded());
+
+    if !no_color {
+        table.with(Modify::new(Rows::first()).with(Color::BOLD));
+    }
+
+    println!("{table}");
+
+    let row_count = result.rows.len();
+    let row_word = if row_count == 1 { "row" } else { "rows" };
+    eprintln!(
+        "({row_count} {row_word}, {}ms)",
+        result.metadata.execution_time_ms
+    );
+}
+
+#[cfg(any(feature = "postgres", feature = "mysql", feature = "duckdb"))]
+fn print_csv(result: &rosql::drivers::ROSQLResult) {
+    let headers: Vec<String> = result.columns.iter().map(|c| c.name.clone()).collect();
+    println!("{}", csv_row(&headers));
+
+    for row in &result.rows {
+        let cells: Vec<String> = row
+            .iter()
+            .map(|v| match v {
+                serde_json::Value::String(s) => s.clone(),
+                serde_json::Value::Null => String::new(),
+                other => other.to_string(),
+            })
+            .collect();
+        println!("{}", csv_row(&cells));
+    }
+}
+
+/// Encode a single CSV row, quoting fields that contain commas, quotes, or newlines.
+#[cfg(any(feature = "postgres", feature = "mysql", feature = "duckdb"))]
+fn csv_row(fields: &[String]) -> String {
+    fields
+        .iter()
+        .map(|f| {
+            if f.contains(',') || f.contains('"') || f.contains('\n') {
+                format!("\"{}\"", f.replace('"', "\"\""))
+            } else {
+                f.clone()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(",")
 }
 
 fn print_errors(errors: &[rosql::ROSQLError]) {
@@ -356,10 +747,21 @@ fn print_errors(errors: &[rosql::ROSQLError]) {
     println!("{}", serde_json::to_string_pretty(&json).unwrap());
 }
 
-fn read_query(query: Option<String>) -> String {
-    match query {
-        Some(q) => q,
-        None => {
+fn read_query(positional: Option<String>, file: Option<std::path::PathBuf>) -> String {
+    match (positional, file) {
+        (Some(_), Some(_)) => {
+            eprintln!("Error: provide either a query string or --file, not both.");
+            std::process::exit(1);
+        }
+        (Some(q), None) => q,
+        (None, Some(path)) => match std::fs::read_to_string(&path) {
+            Ok(s) => s.trim().to_string(),
+            Err(err) => {
+                eprintln!("Error reading {}: {err}", path.display());
+                std::process::exit(1);
+            }
+        },
+        (None, None) => {
             let mut buf = String::new();
             io::stdin()
                 .read_to_string(&mut buf)

--- a/website/docs/cli.mdx
+++ b/website/docs/cli.mdx
@@ -1,29 +1,46 @@
 ---
 title: CLI Reference
-description: Complete reference for the rosql command-line tool — parse, compile, query, validate, and serve
+description: Complete reference for the rosql command-line tool — parse, compile, query, validate, schema, and serve
 sidebar_position: 3
-keywords: [rosql, cli, command line, parse, compile, query, validate, serve]
+keywords: [rosql, cli, command line, parse, compile, query, validate, schema, serve]
 ---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 # CLI Reference
 
 The `rosql` CLI requires the `server` feature flag.
 
-**One-liner install (Linux x86_64 / arm64, macOS Apple Silicon):**
+**Install:**
+
+<Tabs>
+  <TabItem value="curl" label="curl | sh" default>
 
 ```bash
 curl -fsSL https://rosql.org/install.sh | sh
 ```
 
-**Build from source (all platforms):**
+Linux x86_64 / arm64 · macOS Intel &amp; Apple Silicon.
+
+  </TabItem>
+  <TabItem value="brew" label="Homebrew (macOS)">
 
 ```bash
-# With Parquet backend (--backend parquet)
-cargo install rosql --features server,duckdb
-
-# With PostgreSQL backend
-cargo install rosql --features server,postgres
+brew install robotopsinc/tap/rosql
 ```
+
+  </TabItem>
+  <TabItem value="cargo" label="cargo install">
+
+```bash
+cargo install rosql --features server,duckdb
+```
+
+All platforms including Windows.
+
+  </TabItem>
+</Tabs>
 
 ## Commands
 
@@ -35,7 +52,8 @@ Parse a ROSQL query and output the AST as JSON.
 rosql parse "FROM traces WHERE duration > 500 ms SINCE 1 hour ago"
 ```
 
-Useful for inspecting the parsed structure of a query and verifying syntax.
+Flags:
+- `--file <path>` — read query from a file instead of a positional argument
 
 ---
 
@@ -55,14 +73,15 @@ LIMIT 100
 ```
 
 Flags:
-- `--backend` — target SQL dialect: `postgres`, `mysql` (required)
-- `--schema` — column naming profile: `otel-postgres` (default), `otel-clickhouse`
+- `--backend` — target SQL dialect: `postgres`, `mysql`, `parquet` (required; env: `ROSQL_BACKEND`)
+- `--schema` — column naming profile: `otel-postgres` (default), `otel-clickhouse` (env: `ROSQL_SCHEMA`)
+- `--file <path>` — read query from a file
 
 ---
 
 ### `rosql query`
 
-Execute a ROSQL query and return results as JSON.
+Execute a ROSQL query and return results.
 
 ```bash
 rosql query "FROM traces WHERE status = 'ERROR'" \
@@ -70,10 +89,46 @@ rosql query "FROM traces WHERE status = 'ERROR'" \
   --url postgresql://user:pass@localhost:5432/db
 ```
 
+Output defaults to a human-readable table. Use `--format json` for scripts.
+
 Flags:
-- `--backend` — driver: `postgres`, `mysql` (required)
-- `--url` — database connection string (required)
-- `--schema` — column naming profile
+- `--backend` — driver: `postgres`, `mysql`, `parquet` (env: `ROSQL_BACKEND`)
+- `--url` — database connection string (env: `ROSQL_URL`)
+- `--schema` — column naming profile (env: `ROSQL_SCHEMA`)
+- `--format` — output format: `table` (default), `json`, `csv`
+- `--no-color` — disable ANSI color codes
+- `--file <path>` — read query from a file
+
+If `--backend` or `--url` are omitted, they are read from `ROSQL_BACKEND` / `ROSQL_URL`
+environment variables or `~/.config/rosql/config.toml`.
+
+---
+
+### `rosql schema`
+
+Inspect which canonical data sources are available on the connected backend.
+
+```bash
+rosql schema --backend parquet --url ./telemetry/
+```
+
+```
+╭─────────────┬──────────────────┬───────────────╮
+│ Source      │ Table            │ Status        │
+├─────────────┼──────────────────┼───────────────┤
+│ traces      │ otel_traces      │ available     │
+│ logs        │ otel_logs        │ available     │
+│ metrics     │ otel_metrics     │ not found     │
+│ topics      │ topic_messages   │ available     │
+│ recordings  │ mcap_metadata    │ not found     │
+╰─────────────┴──────────────────┴───────────────╯
+```
+
+Flags:
+- `--backend` — driver (env: `ROSQL_BACKEND`)
+- `--url` — connection string (env: `ROSQL_URL`)
+- `--format` — `table` (default), `json`, `csv`
+- `--no-color` — disable color
 
 ---
 
@@ -88,6 +143,9 @@ rosql validate "SELECT * FROM logs"
 rosql validate "INSERT INTO logs"
 # exit 1 — invalid: INSERT not supported
 ```
+
+Flags:
+- `--file <path>` — read query from a file
 
 Useful in CI pipelines to validate stored queries.
 
@@ -136,17 +194,49 @@ The server exposes the `ParserService` proto interface (defined in `proto/rosql/
 
 ---
 
+## Global flags
+
+| Flag | Description |
+|------|-------------|
+| `--no-color` | Disable ANSI color codes for all output. Auto-disabled when stdout is not a TTY. |
+| `--help` | Print help for any subcommand. |
+| `--version` | Print the installed version. |
+
+---
+
+## Config file
+
+`~/.config/rosql/config.toml` sets default values for `--backend`, `--url`, and `--schema`.
+
+```toml
+[default]
+backend = "postgres"
+url = "postgresql://user:pass@localhost:5432/telemetry"
+schema = "otel-postgres"
+```
+
+Precedence: CLI flag > `ROSQL_*` environment variable > config file > built-in default.
+
+---
+
+## Environment variables
+
+| Variable | Equivalent flag | Description |
+|----------|-----------------|-------------|
+| `ROSQL_BACKEND` | `--backend` | Default backend for `query`, `schema`, `compile` |
+| `ROSQL_URL` | `--url` | Default connection URL for `query` and `schema` |
+| `ROSQL_SCHEMA` | `--schema` | Default schema profile |
+
+---
+
 ## Schema profiles
 
-All commands that interact with a database accept `--schema`:
+| Profile | Columns | Exporter |
+|---------|---------|----------|
+| `otel-postgres` (default) | snake_case: `trace_id`, `span_name` | OTel Collector PostgreSQL exporter |
+| `otel-clickhouse` | PascalCase: `TraceId`, `SpanName` | OTel Collector ClickHouse exporter |
 
-```bash
-# lowercase columns (PostgreSQL default OTel exporter)
-rosql query "FROM traces" --backend postgres --schema otel-postgres
-
-# PascalCase columns (ClickHouse OTel exporter)
-rosql query "FROM traces" --backend clickhouse --schema otel-clickhouse
-```
+---
 
 ## Pre-built binaries
 
@@ -154,5 +244,7 @@ rosql query "FROM traces" --backend clickhouse --schema otel-clickhouse
 |----------|-------------|----------|
 | Linux | x86_64 | [GitHub Releases](https://github.com/RobotOpsInc/rosql/releases) |
 | Linux | aarch64 | [GitHub Releases](https://github.com/RobotOpsInc/rosql/releases) |
+| macOS | Apple Silicon (aarch64) | [GitHub Releases](https://github.com/RobotOpsInc/rosql/releases) |
+| macOS | Intel (x86_64) | [GitHub Releases](https://github.com/RobotOpsInc/rosql/releases) |
 
 Other platforms: build from source (see [Quickstart →](./quickstart)).

--- a/website/docs/quickstart.mdx
+++ b/website/docs/quickstart.mdx
@@ -15,13 +15,22 @@ Get ROSQL running against your ROS2 telemetry data in under 5 minutes.
 ## Install the CLI
 
 <Tabs>
-  <TabItem value="prebuilt" label="Pre-built binary" default>
+  <TabItem value="prebuilt" label="curl | sh" default>
 
 ```bash
 curl -fsSL https://rosql.org/install.sh | sh
 ```
 
-Linux x86_64, Linux arm64, and macOS Apple Silicon. Installs to `~/.local/bin/` with the Parquet backend included.
+Linux x86_64, Linux arm64, macOS Intel, and macOS Apple Silicon. Installs to `~/.local/bin/` with the Parquet backend included.
+
+  </TabItem>
+  <TabItem value="brew" label="Homebrew (macOS)">
+
+```bash
+brew install robotopsinc/tap/rosql
+```
+
+Intel and Apple Silicon. Supports `brew upgrade rosql` and `brew uninstall rosql`.
 
   </TabItem>
   <TabItem value="cargo" label="cargo install">
@@ -37,7 +46,7 @@ cargo install rosql --features server,postgres
 cargo install rosql --features server,duckdb,postgres
 ```
 
-Windows, Intel Mac, and all other platforms. Requires Rust stable — [rustup.rs](https://rustup.rs).
+All platforms including Windows. Requires Rust stable — [rustup.rs](https://rustup.rs).
 
   </TabItem>
   <TabItem value="source" label="Build from source">
@@ -66,15 +75,15 @@ rosql query "FROM traces WHERE status = 'ERROR' SINCE 1 hour ago" \
   --url ./telemetry/robotops_demo_agent/20260403-141530/
 ```
 
-```json
-{
-  "columns": ["timestamp", "trace_id", "span_id", "span_name_col", "service_name", "duration", "status_code"],
-  "rows": [
-    ["2026-04-03T14:32:11.012Z", "a3f1c9d2...", "f0e1d2c3...", "navigate_to_pose", "bt_navigator", 1423187000, "ERROR"]
-  ],
-  "metadata": { "rows_returned": 1, "elapsed_ms": 12 }
-}
 ```
+╭──────────────────────────────┬──────────────────┬──────────────────┬──────────────────────┬───────────────┬────────────┬─────────────╮
+│ timestamp                    │ trace_id         │ span_id          │ span_name_col        │ service_name  │ duration   │ status_code │
+├──────────────────────────────┼──────────────────┼──────────────────┼──────────────────────┼───────────────┼────────────┼─────────────┤
+│ 2026-04-03T14:32:11.012Z     │ a3f1c9d2...      │ f0e1d2c3...      │ navigate_to_pose     │ bt_navigator  │ 1423187000 │ ERROR       │
+╰──────────────────────────────┴──────────────────┴──────────────────┴──────────────────────┴───────────────┴────────────┴─────────────╯
+```
+
+Use `--format json` for programmatic consumption, or `--format csv` for export.
 
 The `--url` directory must follow the demo-agent output layout:
 

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -3,6 +3,8 @@ import Link from '@docusaurus/Link';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
 import CodeBlock from '@theme/CodeBlock';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 import Head from '@docusaurus/Head';
 import { Bot, ChartScatter, Table, Share2, Terminal, Database, BarChart2, ArrowRight, Ruler, BarChart3 } from 'lucide-react';
 import { RosqlRepl } from '@site/src/components/RosqlRepl';
@@ -362,16 +364,36 @@ export default function Home(): ReactNode {
           <div className="container">
             <h2 style={{ textAlign: 'center', marginBottom: '0.5rem' }}>Quick start</h2>
             <p style={{ textAlign: 'center', color: 'var(--ifm-color-emphasis-600)', marginBottom: '2rem', fontSize: '0.9rem' }}>
-              Linux x86_64 / arm64 · macOS Apple Silicon
+              Linux · macOS (Intel &amp; Apple Silicon) · Windows via cargo
             </p>
             <div style={{ maxWidth: 720, margin: '0 auto' }}>
-              <CodeBlock language="bash" title="Install (Linux x86_64 / arm64 · macOS Apple Silicon)">
-                {`curl -fsSL https://rosql.org/install.sh | sh`}
-              </CodeBlock>
-              <p style={{ textAlign: 'center', color: 'var(--ifm-color-emphasis-600)', fontSize: '0.85rem', margin: '0.25rem 0 1.5rem' }}>
-                Windows · Intel Mac · building from source → <Link to="/docs/quickstart">Full quickstart</Link>
-              </p>
-              <CodeBlock language="bash" title="Run your first query">
+              <Tabs>
+                <TabItem value="curl" label="curl | sh" default>
+                  <CodeBlock language="bash">
+                    {`curl -fsSL https://rosql.org/install.sh | sh`}
+                  </CodeBlock>
+                  <p style={{ color: 'var(--ifm-color-emphasis-600)', fontSize: '0.85rem', marginTop: '0.5rem' }}>
+                    Linux x86_64 / arm64 · macOS Intel &amp; Apple Silicon. Installs to <code>~/.local/bin/</code>.
+                  </p>
+                </TabItem>
+                <TabItem value="brew" label="Homebrew (macOS)">
+                  <CodeBlock language="bash">
+                    {`brew install robotopsinc/tap/rosql`}
+                  </CodeBlock>
+                  <p style={{ color: 'var(--ifm-color-emphasis-600)', fontSize: '0.85rem', marginTop: '0.5rem' }}>
+                    Intel &amp; Apple Silicon. Supports <code>brew upgrade rosql</code>.
+                  </p>
+                </TabItem>
+                <TabItem value="cargo" label="cargo install">
+                  <CodeBlock language="bash">
+                    {`cargo install rosql --features server,duckdb`}
+                  </CodeBlock>
+                  <p style={{ color: 'var(--ifm-color-emphasis-600)', fontSize: '0.85rem', marginTop: '0.5rem' }}>
+                    All platforms including Windows. Requires Rust stable — <a href="https://rustup.rs">rustup.rs</a>.
+                  </p>
+                </TabItem>
+              </Tabs>
+              <CodeBlock language="bash" title="Run your first query" style={{ marginTop: '1.5rem' }}>
                 {`rosql query "FROM traces WHERE status = 'ERROR' SINCE 1 hour ago" \\
   --backend parquet \\
   --url <your-telemetry-dir>  # see quickstart for S3, PostgreSQL, and all options`}

--- a/website/versioned_docs/version-0.4/cli.mdx
+++ b/website/versioned_docs/version-0.4/cli.mdx
@@ -1,29 +1,46 @@
 ---
 title: CLI Reference
-description: Complete reference for the rosql command-line tool — parse, compile, query, validate, and serve
+description: Complete reference for the rosql command-line tool — parse, compile, query, validate, schema, and serve
 sidebar_position: 3
-keywords: [rosql, cli, command line, parse, compile, query, validate, serve]
+keywords: [rosql, cli, command line, parse, compile, query, validate, schema, serve]
 ---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 # CLI Reference
 
 The `rosql` CLI requires the `server` feature flag.
 
-**One-liner install (Linux x86_64 / arm64 · macOS Apple Silicon):**
+**Install:**
+
+<Tabs>
+  <TabItem value="curl" label="curl | sh" default>
 
 ```bash
 curl -fsSL https://rosql.org/install.sh | sh
 ```
 
-**Build from source (all platforms):**
+Linux x86_64 / arm64 · macOS Intel &amp; Apple Silicon.
+
+  </TabItem>
+  <TabItem value="brew" label="Homebrew (macOS)">
 
 ```bash
-# With Parquet backend (--backend parquet)
-cargo install rosql --features server,duckdb
-
-# With PostgreSQL backend
-cargo install rosql --features server,postgres
+brew install robotopsinc/tap/rosql
 ```
+
+  </TabItem>
+  <TabItem value="cargo" label="cargo install">
+
+```bash
+cargo install rosql --features server,duckdb
+```
+
+All platforms including Windows.
+
+  </TabItem>
+</Tabs>
 
 ## Commands
 
@@ -35,7 +52,8 @@ Parse a ROSQL query and output the AST as JSON.
 rosql parse "FROM traces WHERE duration > 500 ms SINCE 1 hour ago"
 ```
 
-Useful for inspecting the parsed structure of a query and verifying syntax.
+Flags:
+- `--file <path>` — read query from a file instead of a positional argument
 
 ---
 
@@ -55,14 +73,15 @@ LIMIT 100
 ```
 
 Flags:
-- `--backend` — target SQL dialect: `postgres`, `mysql`, `parquet` (required)
-- `--schema` — column naming profile: `otel-postgres` (default), `otel-clickhouse`
+- `--backend` — target SQL dialect: `postgres`, `mysql`, `parquet` (required; env: `ROSQL_BACKEND`)
+- `--schema` — column naming profile: `otel-postgres` (default), `otel-clickhouse` (env: `ROSQL_SCHEMA`)
+- `--file <path>` — read query from a file
 
 ---
 
 ### `rosql query`
 
-Execute a ROSQL query and return results as JSON.
+Execute a ROSQL query and return results.
 
 ```bash
 rosql query "FROM traces WHERE status = 'ERROR'" \
@@ -70,10 +89,46 @@ rosql query "FROM traces WHERE status = 'ERROR'" \
   --url postgresql://user:pass@localhost:5432/db
 ```
 
+Output defaults to a human-readable table. Use `--format json` for scripts.
+
 Flags:
-- `--backend` — driver: `postgres`, `mysql`, `parquet` (required)
-- `--url` — database connection string or local/S3 path (required)
-- `--schema` — column naming profile
+- `--backend` — driver: `postgres`, `mysql`, `parquet` (env: `ROSQL_BACKEND`)
+- `--url` — database connection string (env: `ROSQL_URL`)
+- `--schema` — column naming profile (env: `ROSQL_SCHEMA`)
+- `--format` — output format: `table` (default), `json`, `csv`
+- `--no-color` — disable ANSI color codes
+- `--file <path>` — read query from a file
+
+If `--backend` or `--url` are omitted, they are read from `ROSQL_BACKEND` / `ROSQL_URL`
+environment variables or `~/.config/rosql/config.toml`.
+
+---
+
+### `rosql schema`
+
+Inspect which canonical data sources are available on the connected backend.
+
+```bash
+rosql schema --backend parquet --url ./telemetry/
+```
+
+```
+╭─────────────┬──────────────────┬───────────────╮
+│ Source      │ Table            │ Status        │
+├─────────────┼──────────────────┼───────────────┤
+│ traces      │ otel_traces      │ available     │
+│ logs        │ otel_logs        │ available     │
+│ metrics     │ otel_metrics     │ not found     │
+│ topics      │ topic_messages   │ available     │
+│ recordings  │ mcap_metadata    │ not found     │
+╰─────────────┴──────────────────┴───────────────╯
+```
+
+Flags:
+- `--backend` — driver (env: `ROSQL_BACKEND`)
+- `--url` — connection string (env: `ROSQL_URL`)
+- `--format` — `table` (default), `json`, `csv`
+- `--no-color` — disable color
 
 ---
 
@@ -88,6 +143,9 @@ rosql validate "SELECT * FROM logs"
 rosql validate "INSERT INTO logs"
 # exit 1 — invalid: INSERT not supported
 ```
+
+Flags:
+- `--file <path>` — read query from a file
 
 Useful in CI pipelines to validate stored queries.
 
@@ -135,17 +193,49 @@ The server exposes the `ParserService` proto interface (defined in `proto/rosql/
 
 ---
 
+## Global flags
+
+| Flag | Description |
+|------|-------------|
+| `--no-color` | Disable ANSI color codes for all output. Auto-disabled when stdout is not a TTY. |
+| `--help` | Print help for any subcommand. |
+| `--version` | Print the installed version. |
+
+---
+
+## Config file
+
+`~/.config/rosql/config.toml` sets default values for `--backend`, `--url`, and `--schema`.
+
+```toml
+[default]
+backend = "postgres"
+url = "postgresql://user:pass@localhost:5432/telemetry"
+schema = "otel-postgres"
+```
+
+Precedence: CLI flag > `ROSQL_*` environment variable > config file > built-in default.
+
+---
+
+## Environment variables
+
+| Variable | Equivalent flag | Description |
+|----------|-----------------|-------------|
+| `ROSQL_BACKEND` | `--backend` | Default backend for `query`, `schema`, `compile` |
+| `ROSQL_URL` | `--url` | Default connection URL for `query` and `schema` |
+| `ROSQL_SCHEMA` | `--schema` | Default schema profile |
+
+---
+
 ## Schema profiles
 
-All commands that interact with a database accept `--schema`:
+| Profile | Columns | Exporter |
+|---------|---------|----------|
+| `otel-postgres` (default) | snake_case: `trace_id`, `span_name` | OTel Collector PostgreSQL exporter |
+| `otel-clickhouse` | PascalCase: `TraceId`, `SpanName` | OTel Collector ClickHouse exporter |
 
-```bash
-# lowercase columns (PostgreSQL default OTel exporter)
-rosql query "FROM traces" --backend postgres --schema otel-postgres
-
-# PascalCase columns (ClickHouse OTel exporter)
-rosql query "FROM traces" --backend clickhouse --schema otel-clickhouse
-```
+---
 
 ## Pre-built binaries
 
@@ -153,5 +243,7 @@ rosql query "FROM traces" --backend clickhouse --schema otel-clickhouse
 |----------|-------------|----------|
 | Linux | x86_64 | [GitHub Releases](https://github.com/RobotOpsInc/rosql/releases) |
 | Linux | aarch64 | [GitHub Releases](https://github.com/RobotOpsInc/rosql/releases) |
+| macOS | Apple Silicon (aarch64) | [GitHub Releases](https://github.com/RobotOpsInc/rosql/releases) |
+| macOS | Intel (x86_64) | [GitHub Releases](https://github.com/RobotOpsInc/rosql/releases) |
 
 Other platforms: build from source (see [Quickstart →](./quickstart)).

--- a/website/versioned_docs/version-0.4/quickstart.mdx
+++ b/website/versioned_docs/version-0.4/quickstart.mdx
@@ -15,13 +15,22 @@ Get ROSQL running against your ROS2 telemetry data in under 5 minutes.
 ## Install the CLI
 
 <Tabs>
-  <TabItem value="prebuilt" label="Pre-built binary" default>
+  <TabItem value="prebuilt" label="curl | sh" default>
 
 ```bash
 curl -fsSL https://rosql.org/install.sh | sh
 ```
 
-Linux x86_64, Linux arm64, and macOS Apple Silicon. Installs to `~/.local/bin/` with the Parquet backend included.
+Linux x86_64, Linux arm64, macOS Intel, and macOS Apple Silicon. Installs to `~/.local/bin/` with the Parquet backend included.
+
+  </TabItem>
+  <TabItem value="brew" label="Homebrew (macOS)">
+
+```bash
+brew install robotopsinc/tap/rosql
+```
+
+Intel and Apple Silicon. Supports `brew upgrade rosql` and `brew uninstall rosql`.
 
   </TabItem>
   <TabItem value="cargo" label="cargo install">
@@ -37,7 +46,7 @@ cargo install rosql --features server,postgres
 cargo install rosql --features server,duckdb,postgres
 ```
 
-Windows, Intel Mac, and all other platforms. Requires Rust stable — [rustup.rs](https://rustup.rs).
+All platforms including Windows. Requires Rust stable — [rustup.rs](https://rustup.rs).
 
   </TabItem>
   <TabItem value="source" label="Build from source">


### PR DESCRIPTION
- rosql query now renders a human-readable table by default (--format json/csv available); this is a breaking change for scripts relying on JSON output — add --format json to restore the prior behavior
- New rosql schema subcommand: probes the connected backend for available OTel data sources (traces, logs, metrics, topics, recordings)
- --file <path> flag on parse/compile/query/validate to read queries from .rosql files
- --no-color global flag; auto-disabled when stdout is not a TTY
- ROSQL_BACKEND, ROSQL_URL, ROSQL_SCHEMA env vars via clap env feature
- ~/.config/rosql/config.toml for persistent per-user defaults
- Add x86_64-apple-darwin (macos-13) to release build matrix
- install.sh now supports Intel Macs instead of erroring
- Release workflow: new update-homebrew-tap job opens a bump PR on RobotOpsInc/homebrew-tap after each release (requires HOMEBREW_TAP_TOKEN)
- Homepage, quickstart, and CLI docs updated with Homebrew install tab and Intel Mac coverage across next and version-0.4 docs
- Bump version to 0.4.9