### PR TITLE
feat: add public demo dataset for zero-friction quickstart

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -217,6 +217,29 @@ jobs:
           CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
         run: cargo publish --no-verify --allow-dirty
 
+  upload-demo-data:
+    name: Upload demo dataset to S3
+    needs: create-release
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::189676910689:role/github-actions-deploy-production
+          aws-region: us-east-1
+
+      - name: Upload Parquet fixtures
+        run: |
+          aws s3 sync examples/parquet/fixtures/ \
+            s3://robotops-production-rosql-demo/data/ \
+            --delete \
+            --no-progress
+
   publish-npm:
     name: Publish to npm
     needs: create-release

--- a/README.md
+++ b/README.md
@@ -120,11 +120,15 @@ brew install robotopsinc/tap/rosql
 # Or build from source (all platforms)
 cargo install rosql --features server,duckdb
 
-# Query local Parquet telemetry files
+# Try the public demo dataset instantly — no setup, no credentials
+rosql query "FROM traces WHERE status = 'ERROR' LIMIT 5" \
+  --backend parquet --url s3://robotops-production-rosql-demo/data
+
+# Query your own local Parquet telemetry files
 rosql query "FROM traces WHERE status = 'ERROR' SINCE 1 hour ago" \
   --backend parquet --url ./telemetry/robotops_demo_agent/20260403-141530/
 
-# Query Parquet files on S3
+# Query Parquet files on a private S3 bucket
 rosql query "FROM traces WHERE status = 'ERROR' SINCE 1 hour ago" \
   --backend parquet --url s3://my-bucket/robot-01/robotops_demo_agent/20260403-141530/
 
@@ -196,6 +200,10 @@ rosql parse "FROM traces WHERE duration > 500 ms SINCE 1 hour ago"
 # Compile → SQL (shows what SQL ROSQL generates — no DB or --url needed)
 rosql compile "FROM traces WHERE duration > 500 ms" --backend parquet
 rosql compile "FROM traces WHERE duration > 500 ms" --backend postgres
+
+# Execute → query results as JSON (public demo dataset — no credentials needed)
+rosql query "FROM traces WHERE status = 'ERROR' LIMIT 5" \
+  --backend parquet --url s3://robotops-production-rosql-demo/data
 
 # Execute → query results as JSON (Parquet backend — local or S3)
 rosql query "FROM traces WHERE status = 'ERROR' SINCE 1 hour ago" \

--- a/website/docs/quickstart.mdx
+++ b/website/docs/quickstart.mdx
@@ -65,25 +65,39 @@ cargo build --release --features server,postgres --bin rosql
   </TabItem>
 </Tabs>
 
-## Your first query — local Parquet files
+## Your first query — no setup required
 
-No database server required. Point ROSQL at a directory of Parquet files from the [demo-agent](https://github.com/RobotOpsInc/rmw_robotops/tree/development/demo-agent) or any OTel exporter:
+Query our public demo dataset instantly. No data source, no credentials, no configuration:
+
+```bash
+rosql query "FROM traces WHERE status = 'ERROR' LIMIT 5" \
+  --backend parquet \
+  --url s3://robotops-production-rosql-demo/data
+```
+
+```
+╭──────────────────┬────────────────┬──────────────────┬────────────────────────────────┬──────────────┬────────────┬─────────────╮
+│ timestamp        │ trace_id       │ span_id          │ span_name_col                  │ service_name │ duration   │ status_code │
+├──────────────────┼────────────────┼──────────────────┼────────────────────────────────┼──────────────┼────────────┼─────────────┤
+│ 1776452455875402 │ trace-amr01-m1 │ span-a01-m1-root │ /navigate_to_pose              │ robot-amr-01 │ 7000000000 │ OK          │
+│ 1776452455975402 │ trace-amr01-m1 │ span-a01-m1-bt   │ /bt_navigator/navigate         │ robot-amr-01 │ 6900000000 │ OK          │
+│ 1776452456075402 │ trace-amr01-m1 │ span-a01-m1-ctrl │ /controller_server/follow_path │ robot-amr-01 │ 6800000000 │ OK          │
+╰──────────────────┴────────────────┴──────────────────┴────────────────────────────────┴──────────────┴────────────┴─────────────╯
+```
+
+The demo dataset is a simulated AMR (robot-amr-01) running three navigation missions — one successful, one battery-critical abort, one timeout. Updated on every ROSQL release.
+
+Use `--format json` for programmatic consumption, or `--format csv` for export.
+
+## Query your own data — local Parquet files
+
+Point ROSQL at a directory of Parquet files from the [demo-agent](https://github.com/RobotOpsInc/rmw_robotops/tree/development/demo-agent) or any OTel exporter:
 
 ```bash
 rosql query "FROM traces WHERE status = 'ERROR' SINCE 1 hour ago" \
   --backend parquet \
   --url ./telemetry/robotops_demo_agent/20260403-141530/
 ```
-
-```
-╭──────────────────────────────┬──────────────────┬──────────────────┬──────────────────────┬───────────────┬────────────┬─────────────╮
-│ timestamp                    │ trace_id         │ span_id          │ span_name_col        │ service_name  │ duration   │ status_code │
-├──────────────────────────────┼──────────────────┼──────────────────┼──────────────────────┼───────────────┼────────────┼─────────────┤
-│ 2026-04-03T14:32:11.012Z     │ a3f1c9d2...      │ f0e1d2c3...      │ navigate_to_pose     │ bt_navigator  │ 1423187000 │ ERROR       │
-╰──────────────────────────────┴──────────────────┴──────────────────┴──────────────────────┴───────────────┴────────────┴─────────────╯
-```
-
-Use `--format json` for programmatic consumption, or `--format csv` for export.
 
 The `--url` directory must follow the demo-agent output layout:
 
@@ -96,7 +110,7 @@ The `--url` directory must follow the demo-agent output layout:
   mcap_metadata/   *.parquet  →  mcap_metadata
 ```
 
-### Query from S3
+### Query a private S3 bucket
 
 ```bash
 rosql query "FROM traces WHERE status = 'ERROR' SINCE 1 hour ago" \

--- a/website/versioned_docs/version-0.4/quickstart.mdx
+++ b/website/versioned_docs/version-0.4/quickstart.mdx
@@ -65,7 +65,29 @@ cargo build --release --features server,postgres --bin rosql
   </TabItem>
 </Tabs>
 
-## Get telemetry data
+## Your first query — no setup required
+
+Query our public demo dataset instantly. No data source, no credentials, no configuration:
+
+```bash
+rosql query "FROM traces WHERE status = 'ERROR' LIMIT 5" \
+  --backend parquet \
+  --url s3://robotops-production-rosql-demo/data
+```
+
+```json
+{
+  "columns": ["timestamp", "trace_id", "span_id", "span_name_col", "service_name", "duration", "status_code"],
+  "rows": [
+    [1776452455875402, "trace-amr01-m1", "span-a01-m1-root", "/navigate_to_pose", "robot-amr-01", 7000000000, "OK"]
+  ],
+  "metadata": { "rows_returned": 3, "elapsed_ms": 353 }
+}
+```
+
+The demo dataset is a simulated AMR (robot-amr-01) running three navigation missions — one successful, one battery-critical abort, one timeout. Updated on every ROSQL release.
+
+## Query your own data
 
 The easiest way to get Parquet telemetry files to query is to run the **[Robot Ops demo-agent](https://github.com/RobotOpsInc/rmw_robotops/tree/development/demo-agent)**, which exports ROS2 traces, logs, metrics, and topic data as Parquet files in the expected layout.
 
@@ -82,25 +104,13 @@ Once the demo-agent has run, you'll have a directory like:
   mcap_metadata/   *.parquet
 ```
 
-## Your first query
-
 ```bash
 rosql query "FROM traces WHERE status = 'ERROR' SINCE 1 hour ago" \
   --backend parquet \
   --url ./telemetry/robotops_demo_agent/20260403-141530/
 ```
 
-```json
-{
-  "columns": ["timestamp", "trace_id", "span_id", "span_name_col", "service_name", "duration", "status_code"],
-  "rows": [
-    ["2026-04-03T14:32:11.012Z", "a3f1c9d2...", "f0e1d2c3...", "navigate_to_pose", "bt_navigator", 1423187000, "ERROR"]
-  ],
-  "metadata": { "rows_returned": 1, "elapsed_ms": 12 }
-}
-```
-
-You can also query Parquet files directly from S3:
+You can also query Parquet files directly from a private S3 bucket:
 
 ```bash
 rosql query "FROM traces WHERE status = 'ERROR' SINCE 1 hour ago" \

--- a/website/versioned_docs/version-0.5/quickstart.mdx
+++ b/website/versioned_docs/version-0.5/quickstart.mdx
@@ -65,25 +65,39 @@ cargo build --release --features server,postgres --bin rosql
   </TabItem>
 </Tabs>
 
-## Your first query — local Parquet files
+## Your first query — no setup required
 
-No database server required. Point ROSQL at a directory of Parquet files from the [demo-agent](https://github.com/RobotOpsInc/rmw_robotops/tree/development/demo-agent) or any OTel exporter:
+Query our public demo dataset instantly. No data source, no credentials, no configuration:
+
+```bash
+rosql query "FROM traces WHERE status = 'ERROR' LIMIT 5" \
+  --backend parquet \
+  --url s3://robotops-production-rosql-demo/data
+```
+
+```
+╭──────────────────┬────────────────┬──────────────────┬────────────────────────────────┬──────────────┬────────────┬─────────────╮
+│ timestamp        │ trace_id       │ span_id          │ span_name_col                  │ service_name │ duration   │ status_code │
+├──────────────────┼────────────────┼──────────────────┼────────────────────────────────┼──────────────┼────────────┼─────────────┤
+│ 1776452455875402 │ trace-amr01-m1 │ span-a01-m1-root │ /navigate_to_pose              │ robot-amr-01 │ 7000000000 │ OK          │
+│ 1776452455975402 │ trace-amr01-m1 │ span-a01-m1-bt   │ /bt_navigator/navigate         │ robot-amr-01 │ 6900000000 │ OK          │
+│ 1776452456075402 │ trace-amr01-m1 │ span-a01-m1-ctrl │ /controller_server/follow_path │ robot-amr-01 │ 6800000000 │ OK          │
+╰──────────────────┴────────────────┴──────────────────┴────────────────────────────────┴──────────────┴────────────┴─────────────╯
+```
+
+The demo dataset is a simulated AMR (robot-amr-01) running three navigation missions — one successful, one battery-critical abort, one timeout. Updated on every ROSQL release.
+
+Use `--format json` for programmatic consumption, or `--format csv` for export.
+
+## Query your own data — local Parquet files
+
+Point ROSQL at a directory of Parquet files from the [demo-agent](https://github.com/RobotOpsInc/rmw_robotops/tree/development/demo-agent) or any OTel exporter:
 
 ```bash
 rosql query "FROM traces WHERE status = 'ERROR' SINCE 1 hour ago" \
   --backend parquet \
   --url ./telemetry/robotops_demo_agent/20260403-141530/
 ```
-
-```
-╭──────────────────────────────┬──────────────────┬──────────────────┬──────────────────────┬───────────────┬────────────┬─────────────╮
-│ timestamp                    │ trace_id         │ span_id          │ span_name_col        │ service_name  │ duration   │ status_code │
-├──────────────────────────────┼──────────────────┼──────────────────┼──────────────────────┼───────────────┼────────────┼─────────────┤
-│ 2026-04-03T14:32:11.012Z     │ a3f1c9d2...      │ f0e1d2c3...      │ navigate_to_pose     │ bt_navigator  │ 1423187000 │ ERROR       │
-╰──────────────────────────────┴──────────────────┴──────────────────┴──────────────────────┴───────────────┴────────────┴─────────────╯
-```
-
-Use `--format json` for programmatic consumption, or `--format csv` for export.
 
 The `--url` directory must follow the demo-agent output layout:
 
@@ -96,7 +110,7 @@ The `--url` directory must follow the demo-agent output layout:
   mcap_metadata/   *.parquet  →  mcap_metadata
 ```
 
-### Query from S3
+### Query a private S3 bucket
 
 ```bash
 rosql query "FROM traces WHERE status = 'ERROR' SINCE 1 hour ago" \


### PR DESCRIPTION
Uploads the sample Parquet fixtures to a public S3 bucket on every release so new users can run their first query without any data source.

- Add upload-demo-data job to release workflow (OIDC auth, syncs examples/parquet/fixtures/ to s3://robotops-production-rosql-demo/data/)
- Update quickstart (docs, versioned docs, README) to lead with the public demo URL — no credentials or setup required