### PR TITLE
docs: rename robot agent prose to TraceHouse

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,7 @@ jobs:
         run: sudo apt-get install -y protobuf-compiler
 
       - name: Install cargo-about
-        run: cargo install cargo-about --locked
+        run: cargo install cargo-about --locked --features cli
 
       - name: Check licenses and generate attribution
         run: cargo about generate about.hbs > /dev/null

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,7 +186,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`FORMAT` clause wires through to hints** — explicit `FORMAT table|timeseries|scalar|trace_tree|graph|path` overrides inferred format hint; inference applies automatically when FORMAT is absent
 - **`ExecutionError`** — new `ROSQLError` variant wraps all database execution failures with data source context and an actionable `suggestion`; no raw `sqlx`/`duckdb` error text ever reaches the user
 - **`CompilerWarning` struct** — replaces `Vec<String>` warnings with structured `{ code, message, suggestion }` objects (e.g. `ANOMALY_NO_FACET`)
-- **OTel conventions doc** — `docs/ros2-otel-conventions.md` updated with the full robot_agent metric set: 17 system metrics, 10 ROS2 runtime metrics, 2 process metrics, deprecated name table, updated ROSQL field alias table
+- **OTel conventions doc** — `docs/ros2-otel-conventions.md` updated with the full TraceHouse metric set: 17 system metrics, 10 ROS2 runtime metrics, 2 process metrics, deprecated name table, updated ROSQL field alias table
 - **Position field mappings** — added `gps.lat`/`gps.lon` aliases, `position.x`/`position.y` aliases, `orientation.yaw` (computed from quaternion), `velocity[N]` and `effort[N]` joint state paths
 - **New otel_registry shorthand fields** — `publish_rate`, `bandwidth`, `cpu_usage`, `memory_usage` now point to canonical metric names; 20+ new shorthand aliases for system, ROS2, and process metrics
 - **Proto additions** — `result.proto` adds `FormatHint` enum, `VisualizationConfig` message, `CompilerWarning` message, and three new fields on `QueryResult` (field numbers 8, 9, 16)

--- a/NOTICE
+++ b/NOTICE
@@ -12,7 +12,7 @@ This product includes third-party software with their own licenses.
 A complete list of third-party attributions is available in THIRD_PARTY_NOTICES
 in each release asset, or by running:
 
-    cargo install cargo-about
+    cargo install cargo-about --locked --features cli
     cargo about generate about.hbs
 
 ROSQL™ is a trademark of Robot Ops Inc.

--- a/docs/ros2-otel-conventions.md
+++ b/docs/ros2-otel-conventions.md
@@ -38,7 +38,7 @@ Implementing this correctly requires middleware-level instrumentation — it can
 
 ## Metric naming conventions
 
-The robot_agent `MetricsCollector` emits metrics using these canonical names. ROSQL exposes them via shorthand field aliases in the query language.
+TraceHouse's `MetricsCollector` emits metrics using these canonical names. ROSQL exposes them via shorthand field aliases in the query language.
 
 ### System metrics
 


### PR DESCRIPTION
## Summary
- Update docs prose references from robot_agent/robot agent to TraceHouse
- Keep telemetry/API/source identifiers unchanged

## Verification
- git diff --check
- UTF-8 read check for changed markdown files
- rg confirmed no remaining docs/website robot_agent or robot agent prose refs; remaining hits are source comments only