### PR TITLE
docs: reword internal guidance in rosql/CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@ ROSQL is designed for **humans** — specifically robotics engineers who know SQ
 - **Clarity over brevity.** Prefer `PATH DEVIATION FOR ROBOT 'r1'` over terse abbreviations.
 - **Every user-facing surface is a design surface.** CLI flags, error messages, docs, and example queries are all part of the language's UX.
 - **Documentation should be intuitive and elegantly communicated.** A user should never encounter a discrepancy between what the docs say and what the code does.
+- **Treat this as internal Robot Ops guidance.** Cross-check changes against the codebase and adjacent docs to keep behavior safe, consistent, and up to date.
 
 ## Before Every Push
 


### PR DESCRIPTION
## Summary\n- Reworded the CLAUDE guidance to frame it as internal Robot Ops guidance\n- Emphasizes cross-checking the codebase and adjacent docs for safety and consistency\n\n## Test Plan\n- Not run; documentation-only change