### PR TITLE
fix(ci): stop Deploy Website failing on pnpm ignored build scripts

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -38,7 +38,10 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: latest
+          # Pin to a major version compatible with pnpm-lock.yaml (lockfileVersion 9.0).
+          # `latest` previously drifted to pnpm 11, which turned ignored build scripts
+          # (core-js) into a hard error and broke the deploy.
+          version: 10
 
       - uses: actions/setup-node@v4
         with:

--- a/website/pnpm-workspace.yaml
+++ b/website/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+ignoredBuiltDependencies:
+  - core-js
+  - core-js-pure


### PR DESCRIPTION
## Problem
The **Deploy Website** workflow failed on `main` at `pnpm install --frozen-lockfile` ([run 26659381040](https://github.com/RobotOpsInc/rosql/actions/runs/26659381040)):

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: core-js-pure@3.49.0, core-js@3.49.0
##[error]Process completed with exit code 1.
```

### Root cause
`pnpm/action-setup` was configured with `version: latest`, which has now drifted to **pnpm 11**. In pnpm 11 (CI), ignored dependency build scripts are a **hard error** instead of a warning. `core-js`/`core-js-pure` ship postinstall scripts that we intentionally do not run.

## Fix
- Add `website/pnpm-workspace.yaml` declaring `ignoredBuiltDependencies: [core-js, core-js-pure]` — makes the "do not build these" decision explicit, so pnpm neither warns nor errors. (pnpm 10.16+ reads this from `pnpm-workspace.yaml`, not the package.json `pnpm` field.)
- Pin pnpm to `version: 10` in the workflow (compatible with `lockfileVersion: 9.0`) so CI no longer drifts with upstream pnpm releases.

## Verification
Reproduced the failure locally (pnpm 11 = error; pnpm 10 = warning), then confirmed with pnpm 10.33.0:
```
CI=true pnpm install --frozen-lockfile  →  EXIT=0, no ignored-build message, lockfile unchanged
```

🤖 AI-assisted: investigation and fix prepared with Claude Code; reviewed for correctness.