### PR TITLE
Promote development → main: fix Deploy Website pnpm failure

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -38,7 +38,10 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: latest
+          # Pin to a major version compatible with pnpm-lock.yaml (lockfileVersion 9.0).
+          # `latest` previously drifted to pnpm 11, which turned ignored build scripts
+          # (core-js) into a hard error and broke the deploy.
+          version: 10
 
       - uses: actions/setup-node@v4
         with:

--- a/website/pnpm-workspace.yaml
+++ b/website/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+ignoredBuiltDependencies:
+  - core-js
+  - core-js-pure


### PR DESCRIPTION
Promotes the CI fix in #116 to `main` to repair the failing **Deploy Website** workflow.

- Declares `ignoredBuiltDependencies` (core-js / core-js-pure) in `website/pnpm-workspace.yaml`
- Pins `pnpm` to v10 in `deploy-website.yml` (no more `version: latest` drift)

Merging will re-trigger the Deploy Website workflow (website/** changed), which should now pass through to deploy.

🤖 AI-assisted with Claude Code; reviewed for correctness.