### PR TITLE
chore: set 0.5.4 release date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.5.4] - 2026-05-20
+## [0.5.4] - 2026-05-29
 
 ### Added
 


### PR DESCRIPTION
Sets the `[0.5.4]` CHANGELOG date to the actual release day (2026-05-29) ahead of cutting the v0.5.4 release.

🤖 AI-assisted with Claude Code.