### PR TITLE
Release prep: 0.5.4 changelog date → main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.5.4] - 2026-05-20
+## [0.5.4] - 2026-05-29
 
 ### Added
 


### PR DESCRIPTION
Promotes the 0.5.4 CHANGELOG date fix (#118) to main ahead of cutting the v0.5.4 release.

🤖 AI-assisted with Claude Code.