### PR TITLE
fix(release): cargo-about cli feature + idempotent publishes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
         run: cargo build --release --features server,duckdb --bin rosql ${{ matrix.cross_target != '' && format('--target {0}', matrix.cross_target) || '' }}
 
       - name: Install cargo-about
-        run: cargo install cargo-about --locked
+        run: cargo install cargo-about --locked --features cli
 
       - name: Generate third-party notices
         run: cargo about generate about.hbs > THIRD_PARTY_NOTICES
@@ -214,7 +214,15 @@ jobs:
       - name: Publish
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
-        run: cargo publish --no-verify --allow-dirty
+        run: |
+          VERSION="${{ needs.create-release.outputs.version }}"
+          if curl -s -H "User-Agent: rosql-release" \
+            "https://crates.io/api/v1/crates/rosql/versions" \
+            | grep -q "\"num\":\"${VERSION}\""; then
+            echo "rosql ${VERSION} already published to crates.io; skipping."
+            exit 0
+          fi
+          cargo publish --no-verify --allow-dirty
 
   upload-demo-data:
     name: Upload demo dataset to S3
@@ -264,4 +272,10 @@ jobs:
 
       - name: Publish with provenance (OIDC trusted publishing)
         working-directory: pkg
-        run: npx --yes npm@11 publish --access public --provenance
+        run: |
+          VERSION="${{ needs.create-release.outputs.version }}"
+          if npm view "@robotops/rosql@${VERSION}" version >/dev/null 2>&1; then
+            echo "@robotops/rosql@${VERSION} already published to npm; skipping."
+            exit 0
+          fi
+          npx --yes npm@11 publish --access public --provenance


### PR DESCRIPTION
## Problem
The v0.5.4 Release run ([26661093816](https://github.com/RobotOpsInc/rosql/actions/runs/26661093816)) published to crates.io and npm successfully, but all 4 `build-binaries` jobs failed at **Generate third-party notices**:

```
warning: none of the package's binaries are available for install using the selected features
error: no such command: `about`
```

`cargo install cargo-about --locked` installs no binary on current cargo-about — the binary is gated behind the `cli` feature. `ci.yml` was fixed for this in 24f54ba, but `release.yml` was missed. Result: no binaries uploaded → finalize-release and update-homebrew-tap skipped.

## Fix
- Add `--features cli` to the cargo-about install in `release.yml` (mirrors `ci.yml`).
- Make the crates.io and npm publish steps **idempotent** (skip if the version is already published), so the release workflow can be re-run to finish binaries / GitHub release / homebrew without erroring on the already-completed publishes.

🤖 AI-assisted with Claude Code; reviewed for correctness.