### PR TITLE
test(conformance): driver-parity conformance suite (ROB-297, AC-Q1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,14 @@ jobs:
       - name: Test
         run: cargo test
 
+      # ROB-297 / AC-Q1: driver-parity conformance gate. Asserts the OSS parser +
+      # dialect/registry conventions against the shared fixture (conformance/cases.json),
+      # the same contract the go_backend ClickHouse planner must satisfy. Run explicitly
+      # so a conformance regression is a clearly-named CI failure (it is also covered by
+      # the `cargo test` step above).
+      - name: Conformance suite (driver parity)
+        run: cargo test --test conformance
+
   test-cli:
     name: Test (CLI integration)
     runs-on: ubuntu-latest

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -1,0 +1,99 @@
+# ROSQL driver-parity conformance suite (ROB-297, AC-Q1)
+
+`conformance/cases.json` is a **shared, machine-readable contract** that keeps the
+OSS `rosql` crate (parser + `src/drivers/` conventions) and the **go_backend
+ClickHouse planner** from drifting on:
+
+- **Data-source → table mappings** (AC-P4): `tf`→`tf_states`, `joints`→`joint_states`,
+  `node_graph`→`node_graph_edges`, `traces`→`otel_traces`, `diagnostics`→`otel_metrics`, etc.
+- **PascalCase ClickHouse column convention** (AC-P2, the case-sensitivity fix):
+  `trace_id`→`TraceId`, `span_name`→`SpanName`, `status`→`StatusCode`, … — while the
+  ROS2-native tables (`tf_states`, `node_graph_edges`, `joint_states`) keep **bare
+  snake_case** columns in both schema profiles.
+- **Presentation-layer `format_hint`** per query shape, including
+  `SHOW NODE GRAPH`→`NodeGraph` and `MESSAGE FLOW`→`DirectedGraph`.
+
+## What the OSS crate actually exposes
+
+The OSS `rosql` crate is a **parser** (ROSQL text → AST) plus `src/drivers/`
+conventions. It does **not** emit ClickHouse SQL — that lives in the go_backend
+planner, and a future OSS ClickHouse *driver* is the separate **ROB-224**. So the
+OSS-side conformance asserts exactly three things, which are all the OSS side owns:
+
+1. `parse(query)` resolves to the correct `DataSource` (→ `data_source_key`).
+2. The registry (`otel_registry(SchemaProfile::OtelClickhouse)`) maps that source to
+   `expected_table` and maps OTel fields to their canonical PascalCase columns.
+3. `infer_format(ast)` yields `expected_format_hint`.
+
+It does **not** assert generated SQL strings (there are none on the OSS side yet).
+That half of the contract — "the planned SQL targets `expected_table` and references
+these PascalCase columns" — is what **go_backend** asserts against the same file.
+
+## Fixture format (`cases.json`)
+
+Top-level keys:
+
+| key | meaning |
+|-----|---------|
+| `$schema_version` | integer; bump on breaking format changes |
+| `schema_profile` | `"OtelClickhouse"` or `"OtelPostgres"` — which column profile the column expectations are written against |
+| `column_cases[]` | canonical column-identifier assertions |
+| `query_cases[]` | per-query source/table/format-hint assertions |
+
+### `column_cases[]`
+
+Two shapes (a case uses exactly one):
+
+```jsonc
+// single-table
+{ "name": "...", "table": "otel_traces",
+  "expected_columns": { "trace_id": "TraceId", "span_name": "SpanName", ... } }
+
+// multi-table
+{ "name": "...",
+  "tables": { "joint_states": { "effort": "effort", ... }, "tf_states": { ... } } }
+```
+
+Each `{ field: column }` entry means: for `schema_profile`, the ROSQL field `field`
+on that table must map to the database column `column`.
+
+### `query_cases[]`
+
+```jsonc
+{
+  "name": "tf_maps_to_tf_states",
+  "query": "FROM tf",
+  "data_source_key": "tf",        // null for compound queries (TRACE, SHOW NODE GRAPH, MESSAGE FLOW)
+  "expected_table": "tf_states",  // null when data_source_key is null
+  "expected_format_hint": "Table" // Debug name of rosql::ast::FormatHint
+}
+```
+
+`expected_format_hint` values are the `FormatHint` enum's Debug names:
+`Table`, `LineChart`, `StackedLineChart`, `BarChart`, `HorizontalBars`, `Gantt`,
+`DirectedGraph`, `NodeGraph`, `ScalarCards`, `LogTable`, `RecordingList`.
+
+Any `*_comment` / `comment` fields are documentation-only and ignored by the loader.
+
+## How go_backend consumes the same cases (parity follow-up)
+
+The go_backend-side test (a **separate change**) loads this exact file (vendored or
+git-submoduled from the rosql repo) and, for each `query_case`:
+
+1. Plans `query` through the ClickHouse planner.
+2. Asserts the generated SQL's primary table == `expected_table`.
+3. For OTel sources, asserts the SQL references the PascalCase columns from the
+   matching `column_cases` entry (and that native-table columns stay snake_case).
+4. Optionally asserts the planner's emitted `format_hint` == `expected_format_hint`.
+
+Because both sides read one file, a change to a table mapping or a column convention
+must be made in `cases.json` and will fail **both** suites until both implementations
+agree — that's the anti-drift guarantee.
+
+## Running
+
+```sh
+cargo test --test conformance      # OSS side
+```
+
+Wired into CI via the default `cargo test` job (`.github/workflows/ci.yml`).

--- a/conformance/cases.json
+++ b/conformance/cases.json
@@ -1,0 +1,170 @@
+{
+  "$schema_version": 1,
+  "description": "ROSQL driver-parity conformance fixture (ROB-297, AC-Q1). This is the shared, machine-readable contract that BOTH the OSS rosql crate (parser + dialect/registry conventions) and the go_backend ClickHouse planner must satisfy. Each case maps a ROSQL query to the data-source -> table mapping (AC-P4), the canonical PascalCase ClickHouse column identifiers for the OTel tables (AC-P2 case-sensitivity fix), and the inferred presentation-layer format_hint. See conformance/README.md for the format spec and how go_backend consumes it.",
+  "schema_profile": "OtelClickhouse",
+  "column_cases": [
+    {
+      "name": "traces_columns_are_pascalcase",
+      "comment": "AC-P2: the ClickHouse OTel exporter uses PascalCase columns. The old bug emitted lowercase (trace_id) against a PascalCase schema. These mappings are the regression guard. 'node' is a map-access field whose backing map column is SpanAttributes (also PascalCase).",
+      "table": "otel_traces",
+      "expected_columns": {
+        "trace_id": "TraceId",
+        "span_id": "SpanId",
+        "parent_span_id": "ParentSpanId",
+        "span_name": "SpanName",
+        "service": "ServiceName",
+        "duration": "Duration",
+        "status": "StatusCode",
+        "node": "SpanAttributes",
+        "timestamp": "Timestamp"
+      }
+    },
+    {
+      "name": "native_robotics_tables_use_bare_columns",
+      "comment": "The ROS2-native tables (tf_states, node_graph_edges, joint_states) are NOT OTel-exported, so their columns stay bare snake_case in BOTH schema profiles. Encoding this prevents an over-eager PascalCase rule from corrupting them.",
+      "tables": {
+        "tf_states": {
+          "robot_id": "robot_id",
+          "parent_frame": "parent_frame",
+          "child_frame": "child_frame",
+          "translation_x": "translation_x"
+        },
+        "node_graph_edges": {
+          "robot_id": "robot_id",
+          "source_node": "source_node",
+          "target_node": "target_node",
+          "topic": "topic",
+          "compatible": "compatible"
+        },
+        "joint_states": {
+          "robot_id": "robot_id",
+          "joint_name": "joint_name",
+          "position": "position",
+          "velocity": "velocity",
+          "effort": "effort"
+        }
+      }
+    }
+  ],
+  "query_cases": [
+    {
+      "name": "logs_table_and_logtable_hint",
+      "query": "FROM logs",
+      "data_source_key": "logs",
+      "expected_table": "otel_logs",
+      "expected_format_hint": "LogTable"
+    },
+    {
+      "name": "system_logs",
+      "query": "FROM system_logs",
+      "data_source_key": "system_logs",
+      "expected_table": "system_logs",
+      "expected_format_hint": "LogTable"
+    },
+    {
+      "name": "traces_scalar_count",
+      "query": "SELECT COUNT(*) FROM traces SINCE 1 hour ago",
+      "data_source_key": "traces",
+      "expected_table": "otel_traces",
+      "expected_format_hint": "ScalarCards"
+    },
+    {
+      "name": "metrics_scalar_avg",
+      "query": "SELECT AVG(cpu) FROM metrics SINCE 1 hour ago",
+      "data_source_key": "metrics",
+      "expected_table": "otel_metrics",
+      "expected_format_hint": "ScalarCards"
+    },
+    {
+      "name": "diagnostics_maps_to_otel_metrics",
+      "comment": "diagnostics is a logical source that shares the otel_metrics table.",
+      "query": "FROM diagnostics",
+      "data_source_key": "diagnostics",
+      "expected_table": "otel_metrics",
+      "expected_format_hint": "Table"
+    },
+    {
+      "name": "topics",
+      "query": "FROM topics",
+      "data_source_key": "topics",
+      "expected_table": "topic_messages",
+      "expected_format_hint": "Table"
+    },
+    {
+      "name": "tf_maps_to_tf_states",
+      "comment": "AC-P4: tf -> tf_states.",
+      "query": "FROM tf",
+      "data_source_key": "tf",
+      "expected_table": "tf_states",
+      "expected_format_hint": "Table"
+    },
+    {
+      "name": "heartbeats",
+      "query": "FROM heartbeats",
+      "data_source_key": "heartbeats",
+      "expected_table": "robot_heartbeats",
+      "expected_format_hint": "Table"
+    },
+    {
+      "name": "recordings",
+      "query": "FROM recordings",
+      "data_source_key": "recordings",
+      "expected_table": "mcap_metadata",
+      "expected_format_hint": "RecordingList"
+    },
+    {
+      "name": "events",
+      "query": "FROM events",
+      "data_source_key": "events",
+      "expected_table": "ros2_events",
+      "expected_format_hint": "Table"
+    },
+    {
+      "name": "node_graph_table_query_is_table_shape",
+      "comment": "AC-P4: node_graph -> node_graph_edges. A plain `FROM node_graph` table query renders as a Table; the DIRECTED_GRAPH / NODE_GRAPH shapes come from the SHOW NODE GRAPH and MESSAGE FLOW compound clauses below.",
+      "query": "FROM node_graph",
+      "data_source_key": "node_graph",
+      "expected_table": "node_graph_edges",
+      "expected_format_hint": "Table"
+    },
+    {
+      "name": "joints_maps_to_joint_states_table_shape",
+      "comment": "AC-P4: joints -> joint_states, and a plain `FROM joints` query renders as a TABLE.",
+      "query": "FROM joints",
+      "data_source_key": "joints",
+      "expected_table": "joint_states",
+      "expected_format_hint": "Table"
+    },
+    {
+      "name": "odom_alias_resolves_to_topic_messages",
+      "comment": "Well-known topic alias resolves through the topics table.",
+      "query": "FROM odom",
+      "data_source_key": "topics",
+      "expected_table": "topic_messages",
+      "expected_format_hint": "Table"
+    },
+    {
+      "name": "show_node_graph_is_node_graph_shape",
+      "comment": "The undirected NODE_GRAPH presentation shape.",
+      "query": "SHOW NODE GRAPH",
+      "data_source_key": null,
+      "expected_table": null,
+      "expected_format_hint": "NodeGraph"
+    },
+    {
+      "name": "message_flow_is_directed_graph_shape",
+      "comment": "node-graph / message-flow DIRECTED_GRAPH shape.",
+      "query": "MESSAGE FLOW FROM TOPIC '/cmd_vel'",
+      "data_source_key": null,
+      "expected_table": null,
+      "expected_format_hint": "DirectedGraph"
+    },
+    {
+      "name": "trace_command_is_gantt",
+      "query": "TRACE 'abc123'",
+      "data_source_key": null,
+      "expected_table": null,
+      "expected_format_hint": "Gantt"
+    }
+  ]
+}

--- a/tests/conformance.rs
+++ b/tests/conformance.rs
@@ -1,0 +1,259 @@
+//! Driver-parity conformance suite (ROB-297, AC-Q1).
+//!
+//! This test runs the OSS parser + dialect/registry conventions against the
+//! shared, machine-readable fixture at `conformance/cases.json`. That fixture is
+//! the *contract* that keeps the OSS rosql column/data-source conventions and the
+//! go_backend ClickHouse planner from drifting:
+//!
+//!   * data-source -> table mappings (AC-P4: `tf`->tf_states, `joints`->joint_states,
+//!     `node_graph`->node_graph_edges, ...)
+//!   * the PascalCase ClickHouse column convention (AC-P2 case-sensitivity fix:
+//!     `trace_id`->`TraceId`, `span_name`->`SpanName`, ...)
+//!   * the inferred presentation-layer `format_hint` per query shape (incl. the
+//!     `SHOW NODE GRAPH` -> NodeGraph and `MESSAGE FLOW` -> DirectedGraph shapes).
+//!
+//! The OSS rosql crate is a *parser* plus `src/drivers/` conventions — it does not
+//! itself emit ClickHouse SQL (that's the go_backend planner, and a future OSS CH
+//! driver is the separate ROB-224). So this suite asserts exactly what the OSS side
+//! exposes: that the parser resolves each query to the right `DataSource`, that the
+//! registry maps that source to the right table and the OTel columns to their
+//! canonical PascalCase identifiers, and that format inference yields the right hint.
+//!
+//! go_backend consumes the SAME `conformance/cases.json` in a follow-up parity test
+//! (a separate change): it loads the file, plans each `query`, and asserts the
+//! generated SQL targets `expected_table` and references the PascalCase columns in
+//! `column_cases` — so the two implementations are pinned to one source of truth.
+
+use rosql::ast::{DataSource, PipelineStage, Query};
+use rosql::drivers::field_registry::data_source_key;
+use rosql::drivers::format_inference::infer_format;
+use rosql::drivers::otel_registry::{otel_registry, SchemaProfile};
+use rosql::parse;
+use serde::Deserialize;
+use std::collections::HashMap;
+
+#[derive(Debug, Deserialize)]
+struct Fixture {
+    schema_profile: String,
+    column_cases: Vec<ColumnCase>,
+    query_cases: Vec<QueryCase>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ColumnCase {
+    name: String,
+    /// Single-table form: `table` + `expected_columns`.
+    table: Option<String>,
+    expected_columns: Option<HashMap<String, String>>,
+    /// Multi-table form: `tables` = { table -> { field -> column } }.
+    tables: Option<HashMap<String, HashMap<String, String>>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct QueryCase {
+    name: String,
+    query: String,
+    /// `None` for compound queries with no FROM source (e.g. TRACE, SHOW NODE GRAPH).
+    data_source_key: Option<String>,
+    expected_table: Option<String>,
+    expected_format_hint: String,
+}
+
+fn load_fixture() -> Fixture {
+    let path = concat!(env!("CARGO_MANIFEST_DIR"), "/conformance/cases.json");
+    let raw = std::fs::read_to_string(path)
+        .unwrap_or_else(|e| panic!("failed to read conformance fixture {path}: {e}"));
+    serde_json::from_str(&raw)
+        .unwrap_or_else(|e| panic!("failed to parse conformance fixture {path}: {e}"))
+}
+
+fn profile_from_str(s: &str) -> SchemaProfile {
+    match s {
+        "OtelClickhouse" => SchemaProfile::OtelClickhouse,
+        "OtelPostgres" => SchemaProfile::OtelPostgres,
+        other => panic!("unknown schema_profile in fixture: {other:?}"),
+    }
+}
+
+/// Extract the primary FROM data source from any query variant.
+/// Compound queries (TRACE, SHOW NODE GRAPH, MESSAGE FLOW) have no FROM source.
+fn primary_source(q: &Query) -> Option<DataSource> {
+    match q {
+        Query::Standard(sq) => Some(sq.data_source.clone()),
+        Query::Pipeline(pq) => pq.stages.iter().find_map(|s| match s {
+            PipelineStage::From(ds) => Some(ds.clone()),
+            _ => None,
+        }),
+        Query::Compound(_) => None,
+    }
+}
+
+/// Render the inferred `FormatHint` to the string the fixture uses (its Debug name).
+fn hint_name(q: &Query) -> String {
+    format!("{:?}", infer_format(q).0)
+}
+
+#[test]
+fn conformance_query_cases() {
+    let fx = load_fixture();
+    let profile = profile_from_str(&fx.schema_profile);
+    let reg = otel_registry(profile);
+
+    let mut failures: Vec<String> = Vec::new();
+
+    for case in &fx.query_cases {
+        let ast = match parse(&case.query) {
+            Ok(ast) => ast,
+            Err(errs) => {
+                failures.push(format!(
+                    "[{}] query failed to parse: {:?}\n  query: {}",
+                    case.name, errs, case.query
+                ));
+                continue;
+            }
+        };
+
+        // 1. data_source_key (AC-P4 source identity)
+        let actual_key = primary_source(&ast).map(|ds| data_source_key(&ds));
+        if actual_key.as_deref() != case.data_source_key.as_deref() {
+            failures.push(format!(
+                "[{}] data_source_key mismatch: expected {:?}, got {:?}\n  query: {}",
+                case.name, case.data_source_key, actual_key, case.query
+            ));
+        }
+
+        // 2. data_source -> table mapping (AC-P4)
+        let actual_table =
+            primary_source(&ast).and_then(|ds| reg.table_name(&ds).map(str::to_string));
+        if actual_table.as_deref() != case.expected_table.as_deref() {
+            failures.push(format!(
+                "[{}] table mapping mismatch: expected {:?}, got {:?}\n  query: {}",
+                case.name, case.expected_table, actual_table, case.query
+            ));
+        }
+
+        // 3. format_hint (presentation-layer shape; incl. DirectedGraph / NodeGraph)
+        let actual_hint = hint_name(&ast);
+        if actual_hint != case.expected_format_hint {
+            failures.push(format!(
+                "[{}] format_hint mismatch: expected {:?}, got {:?}\n  query: {}",
+                case.name, case.expected_format_hint, actual_hint, case.query
+            ));
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "conformance query-case failures ({}):\n{}",
+        failures.len(),
+        failures.join("\n")
+    );
+}
+
+#[test]
+fn conformance_column_cases() {
+    let fx = load_fixture();
+    let profile = profile_from_str(&fx.schema_profile);
+    let reg = otel_registry(profile);
+
+    let mut failures: Vec<String> = Vec::new();
+
+    // Flatten single-table and multi-table column cases into (table, field, expected_column).
+    let mut checks: Vec<(String, String, String, String)> = Vec::new();
+    for cc in &fx.column_cases {
+        match (&cc.table, &cc.expected_columns, &cc.tables) {
+            (Some(table), Some(cols), None) => {
+                for (field, col) in cols {
+                    checks.push((cc.name.clone(), table.clone(), field.clone(), col.clone()));
+                }
+            }
+            (None, None, Some(tables)) => {
+                for (table, cols) in tables {
+                    for (field, col) in cols {
+                        checks.push((cc.name.clone(), table.clone(), field.clone(), col.clone()));
+                    }
+                }
+            }
+            _ => panic!(
+                "column_case '{}' must have either (table + expected_columns) or (tables)",
+                cc.name
+            ),
+        }
+    }
+
+    for (case, table, field, expected_col) in checks {
+        match reg.resolve_for_table(&field, &table) {
+            Some(def) => {
+                if def.source_table != table {
+                    failures.push(format!(
+                        "[{case}] field '{field}' resolved to table '{}' not '{table}'",
+                        def.source_table
+                    ));
+                }
+                if def.column != expected_col {
+                    failures.push(format!(
+                        "[{case}] {table}.{field} column mismatch: expected {:?}, got {:?}",
+                        expected_col, def.column
+                    ));
+                }
+            }
+            None => failures.push(format!(
+                "[{case}] field '{field}' not registered for table '{table}'"
+            )),
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "conformance column-case failures ({}):\n{}",
+        failures.len(),
+        failures.join("\n")
+    );
+}
+
+/// Guard: every `DataSource` that maps to a table must be exercised by at least one
+/// query case, so a newly-added source can't silently bypass the parity contract.
+#[test]
+fn conformance_covers_every_table_backed_source() {
+    let fx = load_fixture();
+    let covered: std::collections::HashSet<&str> = fx
+        .query_cases
+        .iter()
+        .filter_map(|c| c.data_source_key.as_deref())
+        .collect();
+
+    // Every DataSource variant that resolves to a table, by its registry key.
+    let all_sources = [
+        DataSource::Logs,
+        DataSource::SystemLogs,
+        DataSource::Traces,
+        DataSource::Metrics,
+        DataSource::Diagnostics,
+        DataSource::Topics,
+        DataSource::Tf,
+        DataSource::Heartbeats,
+        DataSource::Recordings,
+        DataSource::Events,
+        DataSource::NodeGraph,
+        DataSource::Joints,
+    ];
+
+    let reg = otel_registry(profile_from_str(&fx.schema_profile));
+    let mut missing: Vec<String> = Vec::new();
+    for ds in &all_sources {
+        // Sanity: each source must resolve to a table in the registry.
+        assert!(
+            reg.table_name(ds).is_some(),
+            "DataSource {ds:?} has no table mapping in the registry"
+        );
+        let key = data_source_key(ds);
+        if !covered.contains(key.as_str()) {
+            missing.push(key);
+        }
+    }
+
+    assert!(
+        missing.is_empty(),
+        "these table-backed data sources are not covered by any conformance query case: {missing:?}"
+    );
+}


### PR DESCRIPTION
## ROB-297 — ROSQL driver-parity conformance suite (AC-Q1)

Adds a **shared, machine-readable conformance fixture** plus a passing Rust test that
encodes the OSS rosql column/data-source conventions as a contract, so they **can't
silently drift** from the go_backend ClickHouse planner.

### What the OSS crate actually exposes
The OSS `rosql` crate is a **parser** (ROSQL → AST) plus `src/drivers/` conventions
(`dialect.rs`, `otel_registry.rs`, `format_inference.rs`). It does **not** emit
ClickHouse SQL — that's the go_backend planner, and a full OSS ClickHouse driver is the
separate **ROB-224**. So this suite asserts exactly the three things the OSS side owns:

1. `parse(query)` resolves to the correct `DataSource` (→ `data_source_key`).
2. The registry (`SchemaProfile::OtelClickhouse`) maps that source to the right table
   and OTel fields to their canonical **PascalCase** columns.
3. `infer_format(ast)` yields the right `format_hint`.

It deliberately does **not** assert generated SQL strings (there are none on the OSS
side yet) — that half of the contract is what go_backend asserts against the same file.

### Files
- **`conformance/cases.json`** — the fixture / contract (JSON; no feature gate, runs in
  default `cargo test`).
- **`tests/conformance.rs`** — loads the fixture and asserts parser + registry +
  format-inference conventions. 3 tests: query cases, column cases, and a coverage
  guard that fails if a table-backed `DataSource` isn't exercised.
- **`conformance/README.md`** — fixture format spec + how go_backend consumes it.
- **`.github/workflows/ci.yml`** — explicit named conformance gate (also covered by the
  existing `cargo test` job).

### What's covered
- **AC-P4 data-source → table mappings**: `tf`→`tf_states`, `joints`→`joint_states`,
  `node_graph`→`node_graph_edges`, `traces`→`otel_traces`, `diagnostics`→`otel_metrics`,
  `recordings`→`mcap_metadata`, `heartbeats`→`robot_heartbeats`, `events`→`ros2_events`,
  `topics`/`odom`→`topic_messages`, plus a coverage test for every table-backed source.
- **AC-P2 PascalCase column convention** (the old lowercase→PascalCase case-sensitivity
  bug): `trace_id`→`TraceId`, `span_name`→`SpanName`, `status`→`StatusCode`,
  `service`→`ServiceName`, `duration`→`Duration`, map column `SpanAttributes`, etc.
  Native ROS2 tables (`tf_states`, `node_graph_edges`, `joint_states`) are asserted to
  keep **bare snake_case** columns in both profiles.
- **format_hint shapes**: `SHOW NODE GRAPH`→`NodeGraph`, `MESSAGE FLOW`→`DirectedGraph`,
  `FROM joints`→`Table`, `FROM logs`→`LogTable`, `TRACE`→`Gantt`, scalar aggs→`ScalarCards`.

### Fixture format (the contract)
`cases.json` has `schema_profile`, `column_cases[]` (`{ field: column }` per table), and
`query_cases[]` (`query` → `data_source_key`, `expected_table`, `expected_format_hint`).
Full spec in `conformance/README.md`.

### How go_backend consumes the same cases (parity follow-up — separate change)
The go_backend test loads this exact `cases.json` and, per `query_case`: plans the query,
asserts the generated SQL's primary table == `expected_table`, and asserts it references
the PascalCase columns from the matching `column_cases` entry. Because both sides read one
file, any mapping/column change must land in `cases.json` and will fail **both** suites
until both implementations agree — that's the anti-drift guarantee.

### Test results
`cargo fmt --check` ✅ · `cargo clippy --all-targets -- -D warnings` ✅ ·
`cargo test` ✅ (full suite green; conformance = 3/3 passing).

Do **not** merge yet — the go_backend parity test is a follow-up.