### PR TITLE
chore(website): drop dead s3_key fallback in RecordingListViz (ROB-186 Phase 2)

### DIFF
--- a/website/src/components/visualizations/RecordingListViz.tsx
+++ b/website/src/components/visualizations/RecordingListViz.tsx
@@ -11,7 +11,7 @@ export function RecordingListViz({ rows }: VizProps) {
       {rows.map((row, i) => {
         const robotId = String(row['robot_id'] ?? '');
         const sessionId = String(row['session_id'] ?? '');
-        const fileUri = String(row['file_uri'] ?? row['s3_key'] ?? '');
+        const fileUri = String(row['file_uri'] ?? '');
         const startTime = String(row['start_time'] ?? '').slice(0, 19);
         const endTime = String(row['end_time'] ?? '').slice(0, 19);
         const topics = row['topics'];


### PR DESCRIPTION
## What

`RecordingListViz` resolved the MCAP location as `row['file_uri'] ?? row['s3_key'] ?? ''`. But `FROM recordings` only ever projects `file_uri` (the otel registry maps the recordings location field to `mcap_metadata.file_uri`; there is no `s3_key` field in rosql), so `row['s3_key']` was always `undefined` — dead defensive code. Now that go-backend populates `file_uri` (ROB-186 expand, backend #143), rely on it alone.

```diff
-        const fileUri = String(row['file_uri'] ?? row['s3_key'] ?? '');
+        const fileUri = String(row['file_uri'] ?? '');
```

## Why now

This is **Phase 2** of the ROB-186 expand→migrate→contract rollout — moving consumers off the legacy `s3_bucket`/`s3_key` columns before the **Phase 3** contract PR drops them from `mcap_metadata`.

**No behavior change**: rosql never returned `s3_key`, so the fallback never fired.

## Phase 2 audit notes

- **web_app**: no change required — it has **zero** `s3_key`/`s3_bucket`/`file_uri` references and renders `RECORDING_LIST` results generically.
- This `RecordingListViz` was the only runtime consumer of an `s3_key` field across the frontends.

Refs ROB-186.